### PR TITLE
Removed world stack

### DIFF
--- a/Include/Assets/Level.h
+++ b/Include/Assets/Level.h
@@ -33,9 +33,13 @@ namespace CE
 		Level& operator=(const Level&) = delete;
 
 		void CreateFromWorld(const World& world);
-		World CreateWorld(bool callBeginPlayImmediately) const;
+		void LoadIntoWorld(World& world) const;
 
-		static World CreateDefaultWorld();
+		// Will never return nullptr
+		std::unique_ptr<World> CreateWorld(bool callBeginPlayImmediately) const;
+
+		// Will never return nullptr
+		static std::unique_ptr<World> CreateDefaultWorld();
 
 	protected:
 		void OnSave(AssetSaveInfo& saveInfo) const override;
@@ -71,7 +75,7 @@ namespace CE
 		// when loading the level. Instead of
 		// discarding the world, we return this
 		// one on the first call to CreateWorld
-		mutable std::optional<World> mWorld{};
+		mutable std::unique_ptr<World> mWorld{};
 		mutable std::optional<BinaryGSONObject> mSerializedWorld{};
 
 		friend ReflectAccess;

--- a/Include/Assets/Script.h
+++ b/Include/Assets/Script.h
@@ -96,9 +96,10 @@ namespace CE
 		// so if this ever changes, you'll know exactly where you need to start fixing things.
 		static constexpr bool sIsTypeIdTheSameAsNameHash = true;
 
-		// Each component script secretly gets assigned a field of type entt::entity with this name.
-		// Upon constructing the component, the correct entity id is assigned.
+		// Each component script secretly gets assigned a field of type entt::entity and World* with these names.
+		// Upon constructing the component, the correct entity id and world is assigned.
 		static constexpr Name sNameOfOwnerField = "Owner"_Name;
+		static constexpr Name sNameOfWorldField = "World"_Name;
 
 		void CollectErrors(ScriptErrorInserter inserter) const;
 

--- a/Include/Components/GridSpawnerComponent.h
+++ b/Include/Components/GridSpawnerComponent.h
@@ -10,10 +10,10 @@ namespace CE
 	{
 	public:
 		void OnConstruct(World&, entt::entity owner);
-		void OnBeginPlay(World&, entt::entity);
+		void OnBeginPlay(World& world, entt::entity);
 
-		void ClearGrid();
-		void SpawnGrid();
+		void ClearGrid(World& world);
+		void SpawnGrid(World& world);
 
 		std::vector<AssetHandle<Prefab>> mTiles{};
 

--- a/Include/EditorSystems/ThumbnailEditorSystem.h
+++ b/Include/EditorSystems/ThumbnailEditorSystem.h
@@ -12,7 +12,7 @@ namespace CE
 	class Texture;
 	class World;
 
-	using GetThumbnailRet = std::variant<AssetHandle<Texture>, World>;
+	using GetThumbnailRet = std::variant<AssetHandle<Texture>, std::unique_ptr<World>>;
 
 	class ThumbnailEditorSystem final :
 		public EditorSystem
@@ -72,9 +72,7 @@ namespace CE
 
 		struct CurrentlyGenerating
 		{
-			CurrentlyGenerating(World&& world, WeakAssetHandle<> forAsset);
-
-			World mWorld;
+			std::unique_ptr<World> mWorld{};
 			WeakAssetHandle<> mForAsset{};
 			FrameBuffer mFrameBuffer{ sGeneratedThumbnailResolution };
 			Timer mNumSecondsSinceLastRequested{};

--- a/Include/Scripting/ScriptPin.h
+++ b/Include/Scripting/ScriptPin.h
@@ -1,16 +1,9 @@
 #pragma once
 #include "ScriptIds.h"
-#include "imnodes/imgui_node_editor.h"
 
-#include "Meta/MetaAny.h"
-#include "Meta/MetaTypeTraits.h"
 #include "Meta/Fwd/MetaFuncFwd.h"
+#include "Meta/MetaTypeTraits.h"
 #include "Scripting/ScriptErrors.h"
-
-namespace CE
-{
-	struct MetaFuncNamedParam;
-}
 
 namespace CE
 {

--- a/Include/Utilities/Imgui/WorldInspect.h
+++ b/Include/Utilities/Imgui/WorldInspect.h
@@ -21,7 +21,7 @@ namespace CE
 		The provided doUndoStack must remain alive for the duration of this
 		objects lifetime.
 		*/
-		WorldInspectHelper(World&& worldThatHasNotYetBegunPlay);
+		WorldInspectHelper(std::unique_ptr<World> worldThatHasNotYetBegunPlay);
 		~WorldInspectHelper();
 
 		/*

--- a/Include/Utilities/Reflect/ReflectComponentType.h
+++ b/Include/Utilities/Reflect/ReflectComponentType.h
@@ -36,12 +36,10 @@ namespace CE
 		MetaFunc& addComponentFunc = entityType.AddFunc(
 			[](MetaFunc::DynamicArgs args, MetaFunc::RVOBuffer) -> FuncResult
 			{
-				World* world = World::TryGetWorldAtTopOfStack();
-				ASSERT(world != nullptr && "Reached a scripting context without pushing a world");
+				World& world = *static_cast<World*>(args[0].GetData());
+				const entt::entity entity = *static_cast<entt::entity*>(args[1].GetData());
 
-				entt::entity entity = *static_cast<entt::entity*>(args[0].GetData());
-
-				Registry& reg = world->GetRegistry();
+				Registry& reg = world.GetRegistry();
 
 				if (reg.HasComponent<T>(entity))
 				{
@@ -61,7 +59,7 @@ namespace CE
 			},
 			Internal::GetAddComponentFuncName(type.GetName()),
 			MetaFunc::Return{ isEmpty ? MakeTypeTraits<void>() : MakeTypeTraits<T&>() },
-			MetaFunc::Params{ { MakeTypeTraits<const entt::entity&>(), "Entity" } });
+			MetaFunc::Params{ { MakeTypeTraits<World&>() }, { MakeTypeTraits<entt::entity>() } });
 
 		if (type.GetProperties().Has(Props::sIsScriptableTag))
 		{

--- a/Include/World/EventManager.h
+++ b/Include/World/EventManager.h
@@ -29,8 +29,6 @@ namespace CE
 			MetaFunc::DynamicArgs argsProvided, 
 			std::span<TypeForm> argFormsProvided);
 
-		// mWorld needs to be updated in World::World(World&&), so we give access to World to do so.
-		friend class World;
 		std::reference_wrapper<World> mWorld;
 
 		std::unordered_map<std::string_view, std::vector<BoundEvent>> mBoundEvents{};

--- a/Include/World/Physics.h
+++ b/Include/World/Physics.h
@@ -52,8 +52,6 @@ namespace CE
 		static MetaType Reflect();
 		REFLECT_AT_START_UP(Physics);
 
-		// mWorld needs to be updated in World::World(World&&), so we give access to World to do so.
-		friend class World;
 		std::reference_wrapper<World> mWorld;
 
 		BVHS mBVHs;

--- a/Include/World/Registry.h
+++ b/Include/World/Registry.h
@@ -157,9 +157,6 @@ namespace CE
 
 		void CallEndPlayEventsForEntity(entt::sparse_set& storage, entt::entity entity, const BoundEvent& endPlayEvent);
 
-		// mWorld needs to be updated in World::World(World&&), so we give access to World to do so.
-		friend World;
-
 		std::reference_wrapper<World> mWorld; 
 		
 		entt::registry mRegistry{};

--- a/Include/World/Registry.h
+++ b/Include/World/Registry.h
@@ -214,8 +214,6 @@ namespace CE
 				}
 			}();
 
-		World::PushWorld(mWorld);
-
 		if constexpr (isEmpty)
 		{
 			mRegistry.emplace<ComponentType>(toEntity, std::forward<AdditonalArgs>(additionalArgs)...);
@@ -233,8 +231,6 @@ namespace CE
 					events.mOnBeginPlay->mFunc.get().InvokeUncheckedUnpacked(GetWorld(), toEntity);
 				}
 			}
-
-			World::PopWorld();
 		}
 		else
 		{
@@ -267,8 +263,6 @@ namespace CE
 					}
 				}
 			}
-
-			World::PopWorld();
 
 			return component;
 		}
@@ -304,7 +298,6 @@ namespace CE
 	template<typename ComponentType>
 	void Registry::RemoveComponent(entt::entity fromEntity)
 	{
-		World::PushWorld(mWorld);
 		static constexpr TypeId componentClassTypeId = MakeStrippedTypeId<ComponentType>();
 		entt::sparse_set* storage = Storage(componentClassTypeId);
 		ASSERT(storage != nullptr);
@@ -332,7 +325,6 @@ namespace CE
 		}
 
 		storage->erase(fromEntity);
-		World::PopWorld();
 	}
 
 	template <typename ComponentType, typename It>
@@ -355,8 +347,6 @@ namespace CE
 			return;
 		}
 
-		World::PushWorld(mWorld);
-
 		if constexpr (sIsReflectable<ComponentType>)
 		{
 			static std::optional<BoundEvent> endPlayEvent =
@@ -376,7 +366,6 @@ namespace CE
 			{
 				if (!storage->contains(fromEntity))
 				{
-					World::PopWorld();
 					return;
 				}
 
@@ -385,7 +374,6 @@ namespace CE
 		}
 
 		storage->remove(fromEntity);
-		World::PopWorld();
 	}
 
 	template<typename It>

--- a/Include/World/World.h
+++ b/Include/World/World.h
@@ -18,13 +18,14 @@ namespace CE
 	{
 	public:
 		World(bool beginPlayImmediately);
-		World(World&& other) noexcept;
+
+		World(World&&) = delete;
 		World(const World&) = delete;
 
-		~World();
-
-		World& operator=(World&& other) noexcept;
+		World& operator=(World&&) noexcept = delete;
 		World& operator=(const World&) = delete;
+
+		~World();
 
 		void Tick(float deltaTime);
 		void Render(FrameBuffer* renderTarget = nullptr);

--- a/Include/World/World.h
+++ b/Include/World/World.h
@@ -76,11 +76,6 @@ namespace CE
 
 		void RequestEndplay();
 
-		static void PushWorld(World& world);
-		static void PopWorld();
-
-		static World* TryGetWorldAtTopOfStack();
-
 		/**
 		 * \brief Will request a transition to a different level.
 		 *

--- a/Include/World/WorldViewport.h
+++ b/Include/World/WorldViewport.h
@@ -23,8 +23,6 @@ namespace CE
 		glm::vec3 ScreenToWorldPlane(glm::vec2 screenPosition, float planeHeight) const;
 
 	private:
-		// mWorld needs to be updated in World::World(World&&), so we give access to World to do so.
-		friend class World;
 		std::reference_wrapper<const World> mWorld;
 
 		// In pixels

--- a/Source/Components/GridSpawnerComponent.cpp
+++ b/Source/Components/GridSpawnerComponent.cpp
@@ -14,24 +14,17 @@ void CE::GridSpawnerComponent::OnConstruct(World&, entt::entity owner)
 	mOwner = owner;
 }
 
-void CE::GridSpawnerComponent::OnBeginPlay(World&, entt::entity)
+void CE::GridSpawnerComponent::OnBeginPlay(World& world, entt::entity)
 {
 	if (mShouldSpawnOnBeginPlay)
 	{
-		SpawnGrid();
+		SpawnGrid(world);
 	}
 }
 
-void CE::GridSpawnerComponent::ClearGrid()
+void CE::GridSpawnerComponent::ClearGrid(World& world)
 {
-	World* const world = World::TryGetWorldAtTopOfStack();
-
-	if (world == nullptr)
-	{
-		return;
-	}
-
-	Registry& reg = world->GetRegistry();
+	Registry& reg = world.GetRegistry();
 
 	TransformComponent* transform = reg.TryGet<TransformComponent>(mOwner);
 
@@ -46,23 +39,16 @@ void CE::GridSpawnerComponent::ClearGrid()
 	}
 }
 
-void CE::GridSpawnerComponent::SpawnGrid()
+void CE::GridSpawnerComponent::SpawnGrid(World& world)
 {
 	if (mTiles.empty())
 	{
 		return;
 	}
 
-	World* const world = World::TryGetWorldAtTopOfStack();
+	ClearGrid(world);
 
-	if (world == nullptr)
-	{
-		return;
-	}
-
-	ClearGrid();
-
-	Registry& reg = world->GetRegistry();
+	Registry& reg = world.GetRegistry();
 	TransformComponent* transform = reg.TryGet<TransformComponent>(mOwner);
 
 	if (transform == nullptr)

--- a/Source/Components/Physics2D/DiskColliderComponent.cpp
+++ b/Source/Components/Physics2D/DiskColliderComponent.cpp
@@ -20,28 +20,6 @@ CE::MetaType CE::DiskColliderComponent::Reflect()
 
 	metaType.AddField(&DiskColliderComponent::mRadius, "mRadius").GetProperties().Add(Props::sIsScriptableTag);
 
-	metaType.AddFunc([](entt::entity owner)
-		{
-			World* world = World::TryGetWorldAtTopOfStack();
-			ASSERT(world != nullptr);
-
-			const auto transform = world->GetRegistry().TryGet<TransformComponent>(owner);
-			if (transform == nullptr)
-			{
-				LOG(LogPhysics, Error, "Entity {} passed to GetScaledRadius does not have a TransformComponent.", entt::to_integral(owner));
-				return 0.0f;
-			}
-			const auto collider = world->GetRegistry().TryGet<DiskColliderComponent>(owner);
-			if (transform == nullptr)
-			{
-				LOG(LogPhysics, Error, "Entity {} passed to GetScaledRadius does not have a DiskColliderComponent.", entt::to_integral(owner));
-				return 0.0f;
-			}
-
-			return collider->CreateTransformedCollider(*transform).mRadius;
-		}, "GetScaledRadius", MetaFunc::ExplicitParams<
-		entt::entity>{}, "Owner of Disk Collider").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
-
 	ReflectComponentType<DiskColliderComponent>(metaType);
 
 	return metaType;

--- a/Source/Core/Engine.cpp
+++ b/Source/Core/Engine.cpp
@@ -163,7 +163,7 @@ void CE::Engine::Run([[maybe_unused]] Name starterLevel)
 	}
 
 	LOG(LogCore, Verbose, "Loading initial level - {}", starterLevel.StringView());
-	World world = level->CreateWorld(true);
+	std::unique_ptr<World> world = level->CreateWorld(true);
 #endif // EDITOR
 
 	Input& input = Input::Get();
@@ -206,14 +206,14 @@ void CE::Engine::Run([[maybe_unused]] Name starterLevel)
 #ifdef EDITOR
 		editor.Tick(deltaTime);
 #else
-		world.Tick(deltaTime);
+		world->Tick(deltaTime);
 
-		if (world.HasRequestedEndPlay())
+		if (world->HasRequestedEndPlay())
 		{
 			break;
 		}
 
-		world.Render();
+		world->Render();
 #endif  // EDITOR
 
 		renderer.RunCommandQueues();

--- a/Source/EditorSystems/AssetEditorSystems/LevelEditorSystem.cpp
+++ b/Source/EditorSystems/AssetEditorSystems/LevelEditorSystem.cpp
@@ -2,7 +2,6 @@
 #include "EditorSystems/AssetEditorSystems/LevelEditorSystem.h"
 
 #include "Utilities/Imgui/WorldInspect.h"
-#include "World/World.h"
 
 CE::LevelEditorSystem::LevelEditorSystem(Level&& asset) :
 	AssetEditorSystem(std::move(asset)),
@@ -36,7 +35,7 @@ void CE::LevelEditorSystem::Tick(const float deltaTime)
 
 void CE::LevelEditorSystem::SaveState(std::ostream& toStream) const
 {
-	AssetEditorSystem<Level>::SaveState(toStream);
+	AssetEditorSystem::SaveState(toStream);
 
 	BinaryGSONObject savedState{};
 	mWorldHelper->SaveState(savedState);
@@ -45,7 +44,7 @@ void CE::LevelEditorSystem::SaveState(std::ostream& toStream) const
 
 void CE::LevelEditorSystem::LoadState(std::istream& fromStream)
 {
-	AssetEditorSystem<Level>::LoadState(fromStream);
+	AssetEditorSystem::LoadState(fromStream);
 
 	BinaryGSONObject savedState{};
 

--- a/Source/Meta/ReflectedTypes/ENTT/ReflectEntity.cpp
+++ b/Source/Meta/ReflectedTypes/ENTT/ReflectEntity.cpp
@@ -57,26 +57,22 @@ MetaType Reflector<T>::Reflect()
 		}, "ToString", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
 
 
-	type.AddFunc([](const entt::entity& entity)
+	type.AddFunc([](const World& world, const entt::entity& entity)
 		{
-			const World* world = World::TryGetWorldAtTopOfStack();
-			ASSERT(world != nullptr);
-			return world->GetRegistry().Valid(entity);
-		}, "IsAlive", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+			return world.GetRegistry().Valid(entity);
+		}, "IsAlive", MetaFunc::ExplicitParams<const World&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
 
 
-	type.AddFunc([](const entt::entity& entity, const ComponentFilter& component)
+	type.AddFunc([](World& world, const entt::entity& entity, const ComponentFilter& component)
 		{
 			if (component == nullptr)
 			{
 				return;
 			}
 
-			World* world = World::TryGetWorldAtTopOfStack();
-			ASSERT(world != nullptr);
-			world->GetRegistry().AddComponent(*component.Get(), entity);
+			world.GetRegistry().AddComponent(*component.Get(), entity);
 
-		}, "AddComponent", MetaFunc::ExplicitParams<const T&, const ComponentFilter&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "AddComponent", MetaFunc::ExplicitParams<World&, const T&, const ComponentFilter&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/UnitTests/LevelAndPrefabSerializationUnitTests.cpp
+++ b/Source/UnitTests/LevelAndPrefabSerializationUnitTests.cpp
@@ -21,9 +21,9 @@ static constexpr std::string_view sTestPrefabName = "__TestPrefab__";
 
 namespace
 {
-	World ReloadUsingLevel(World&& world);
+	std::unique_ptr<World> ReloadUsingLevel(std::unique_ptr<World> world);
 
-	World ReloadUsingPrefab(World&& world, entt::entity entity);
+	std::unique_ptr<World> ReloadUsingPrefab(std::unique_ptr<World> world, entt::entity entity);
 
 	struct PrefabChange
 	{
@@ -37,7 +37,7 @@ namespace
 		static MetaType Reflect();
 	};
 
-	UnitTest::Result TestPrefabChanges(World&& initialWorld,
+	UnitTest::Result TestPrefabChanges(std::unique_ptr<World> initialWorld,
 		entt::entity initialEntity,
 		std::vector<PrefabChange> changes,
 		std::function<void(World&, entt::entity)>&& changePrefabInstanceInWorld = {});
@@ -51,8 +51,8 @@ UNIT_TEST(Serialization, NoPrefabsLevelSerialization)
 	static const std::string childName = "ChildName\t\n\t!!";
 	static constexpr glm::vec3 childPosition = -glm::vec3{ 102.0f, 2035.f, -2035.f };
 
-	World world{ false };
-	Registry& reg = world.GetRegistry();
+	std::unique_ptr<World> world = std::make_unique<World>(false);
+	Registry& reg = world->GetRegistry();
 
 	const entt::entity parent = reg.Create();
 	const entt::entity child = reg.Create();
@@ -68,8 +68,8 @@ UNIT_TEST(Serialization, NoPrefabsLevelSerialization)
 		childTransform.SetParent(&reg.Get<TransformComponent>(parent));
 	}
 
-	World reloadedWorld = ReloadUsingLevel(std::move(world));
-	Registry& reloadedReg = reloadedWorld.GetRegistry();
+	const std::unique_ptr<World> reloadedWorld = ReloadUsingLevel(std::move(world));
+	Registry& reloadedReg = reloadedWorld->GetRegistry();
 
 	TEST_ASSERT(reloadedReg.Valid(parent));
 	TEST_ASSERT(reloadedReg.Valid(child));
@@ -100,8 +100,8 @@ UNIT_TEST(Serialization, PrefabsSerialization)
 	static const std::string childName = "ChildName\t\n\t!!";
 	static constexpr glm::vec3 childPosition = -glm::vec3{ 102.0f, 2035.f, -2035.f };
 
-	World world{ false };
-	Registry& reg = world.GetRegistry();
+	std::unique_ptr<World> world = std::make_unique<World>(false);
+	Registry& reg = world->GetRegistry();
 
 	const entt::entity parent = reg.Create();
 	const entt::entity child = reg.Create();
@@ -117,8 +117,8 @@ UNIT_TEST(Serialization, PrefabsSerialization)
 		childTransform.SetParent(&reg.Get<TransformComponent>(parent));
 	}
 
-	World reloadedWorld = ReloadUsingPrefab(std::move(world), parent);
-	Registry& reloadedReg = reloadedWorld.GetRegistry();
+	std::unique_ptr<World>  reloadedWorld = ReloadUsingPrefab(std::move(world), parent);
+	Registry& reloadedReg = reloadedWorld->GetRegistry();
 
 	TEST_ASSERT(reloadedReg.Valid(parent));
 	TEST_ASSERT(reloadedReg.Valid(child));
@@ -149,13 +149,13 @@ UNIT_TEST(Serialization, PrefabsSerialization)
 
 UNIT_TEST(Serialization, EmptyEntityLevelSerialization)
 {
-	World world{ false };
-	Registry& reg = world.GetRegistry();
+	std::unique_ptr<World> world = std::make_unique<World>(false);
+	Registry& reg = world->GetRegistry();
 
 	const entt::entity entity = reg.Create();
 
-	World reloadedWorld = ReloadUsingLevel(std::move(world));
-	Registry& reloadedReg = reloadedWorld.GetRegistry();
+	std::unique_ptr<World> reloadedWorld = ReloadUsingLevel(std::move(world));
+	Registry& reloadedReg = reloadedWorld->GetRegistry();
 
 	TEST_ASSERT(reloadedReg.Valid(entity));
 	TEST_ASSERT(reloadedReg.Storage<entt::entity>().in_use() == 1);
@@ -165,15 +165,15 @@ UNIT_TEST(Serialization, EmptyEntityLevelSerialization)
 
 UNIT_TEST(Serialization, EmptyComponentLevelSerialization)
 {
-	World world{ false };
-	Registry& reg = world.GetRegistry();
+	std::unique_ptr<World> world = std::make_unique<World>(false);
+	Registry& reg = world->GetRegistry();
 
 	const entt::entity entity = reg.Create(); 
 	reg.AddComponent<EmptyEventTestingComponent>(entity);
 	TEST_ASSERT(reg.HasComponent<EmptyEventTestingComponent>(entity));
 
-	World reloadedWorld = ReloadUsingLevel(std::move(world));
-	Registry& reloadedReg = reloadedWorld.GetRegistry();
+	std::unique_ptr<World> reloadedWorld = ReloadUsingLevel(std::move(world));
+	Registry& reloadedReg = reloadedWorld->GetRegistry();
 
 	TEST_ASSERT(reloadedReg.Valid(entity));
 	TEST_ASSERT(reloadedReg.Storage<entt::entity>().in_use() == 1);
@@ -184,13 +184,13 @@ UNIT_TEST(Serialization, EmptyComponentLevelSerialization)
 
 UNIT_TEST(Serialization, EmptyEntityPrefabSerialization)
 {
-	World world{ false };
-	Registry& reg = world.GetRegistry();
+	std::unique_ptr<World> world = std::make_unique<World>(false);
+	Registry& reg = world->GetRegistry();
 
 	const entt::entity entity = reg.Create();
 
-	World reloadedWorld = ReloadUsingPrefab(std::move(world), entity);
-	Registry& reloadedReg = reloadedWorld.GetRegistry();
+	std::unique_ptr<World> reloadedWorld = ReloadUsingPrefab(std::move(world), entity);
+	Registry& reloadedReg = reloadedWorld->GetRegistry();
 
 	TEST_ASSERT(reloadedReg.Valid(entity));
 	TEST_ASSERT(reloadedReg.Storage<entt::entity>().in_use() == 1);
@@ -200,9 +200,9 @@ UNIT_TEST(Serialization, EmptyEntityPrefabSerialization)
 
 UNIT_TEST(Serialization, PrefabAddComponent)
 {
-	World world{ false };
+	std::unique_ptr<World> world = std::make_unique<World>(false);
 
-	Registry& reg = world.GetRegistry();
+	Registry& reg = world->GetRegistry();
 	entt::entity entity = reg.Create();
 
 	return TestPrefabChanges(std::move(world), entity,
@@ -229,9 +229,9 @@ UNIT_TEST(Serialization, PrefabAddComponent)
 
 UNIT_TEST(Serialization, PrefabRemoveComponent)
 {
-	World world{ false };
+	std::unique_ptr<World> world = std::make_unique<World>(false);
 
-	Registry& reg = world.GetRegistry();
+	Registry& reg = world->GetRegistry();
 	entt::entity entity = reg.Create();
 	reg.AddComponent<NameComponent>(entity);
 
@@ -261,9 +261,9 @@ UNIT_TEST(Serialization, PrefabRemoveComponent)
 
 UNIT_TEST(Serialization, PrefabAddChild)
 {
-	World world{ false };
+	std::unique_ptr<World> world = std::make_unique<World>(false);
 
-	Registry& reg = world.GetRegistry();
+	Registry& reg = world->GetRegistry();
 	entt::entity parent = reg.Create();
 	reg.AddComponent<TransformComponent>(parent);
 
@@ -315,9 +315,9 @@ UNIT_TEST(Serialization, PrefabAddChild)
 
 UNIT_TEST(Serialization, PrefabRemoveChild)
 {
-	World world{ false };
+	std::unique_ptr<World> world = std::make_unique<World>(false);
 
-	Registry& reg = world.GetRegistry();
+	Registry& reg = world->GetRegistry();
 	entt::entity parent = reg.Create();
 	reg.AddComponent<TransformComponent>(parent);
 
@@ -369,9 +369,9 @@ UNIT_TEST(Serialization, PrefabRemoveChild)
 
 UNIT_TEST(Serialization, PrefabChildRemovedWhileInstancesHaveChanges)
 {
-	World world{ false };
+	std::unique_ptr<World> world = std::make_unique<World>(false);
 
-	Registry& reg = world.GetRegistry();
+	Registry& reg = world->GetRegistry();
 	entt::entity parent = reg.Create();
 	reg.AddComponent<TransformComponent>(parent);
 
@@ -445,8 +445,8 @@ UNIT_TEST(Serialization, CopyPaste)
 	static const std::string childName = "ChildName\t\n\t!!";
 	static constexpr glm::vec3 childPosition = -glm::vec3{ 102.0f, 2035.f, -2035.f };
 
-	World world{ false };
-	Registry& reg = world.GetRegistry();
+	std::unique_ptr<World> world = std::make_unique<World>(false);
+	Registry& reg = world->GetRegistry();
 
 	const entt::entity parent = reg.Create();
 	const entt::entity child = reg.Create();
@@ -503,8 +503,8 @@ UNIT_TEST(Serialization, CopyPaste)
 
 			if (depthRemaining > 0)
 			{
-				BinaryGSONObject copy = Archiver::Serialize(world, std::array<entt::entity, 2>{ parent, child }, true);
-				const std::vector<entt::entity> copiedEntities = Archiver::Deserialize(world, copy);
+				BinaryGSONObject copy = Archiver::Serialize(*world, std::array<entt::entity, 2>{ parent, child }, true);
+				const std::vector<entt::entity> copiedEntities = Archiver::Deserialize(*world, copy);
 				entitiesToCheck.insert(entitiesToCheck.end(), copiedEntities.begin(), copiedEntities.end());
 				return doesMatch(entitiesToCheck);
 			}
@@ -517,10 +517,10 @@ UNIT_TEST(Serialization, CopyPaste)
 
 namespace
 {
-	World ReloadUsingLevel(World&& world)
+	std::unique_ptr<World> ReloadUsingLevel(std::unique_ptr<World> world)
 	{
 		Level testLevel{ sTestLevelName };
-		testLevel.CreateFromWorld(world);
+		testLevel.CreateFromWorld(*world);
 
 		AssetLoadInfo savedLevel = testLevel.Save();
 
@@ -528,17 +528,17 @@ namespace
 		return reloadedLevel.CreateWorld(false);
 	}
 
-	World ReloadUsingPrefab(World&& world, entt::entity entity)
+	std::unique_ptr<World> ReloadUsingPrefab(std::unique_ptr<World> world, entt::entity entity)
 	{
 		Prefab testPrefab{ sTestPrefabName };
-		testPrefab.CreateFromEntity(world, entity);
+		testPrefab.CreateFromEntity(*world, entity);
 
 		AssetLoadInfo savedPrefab = testPrefab.Save();
 
 		Prefab reloadedPrefab{ savedPrefab };
 
-		World reloadedWorld{ false };
-		Registry& reloadedReg = reloadedWorld.GetRegistry();
+		std::unique_ptr<World> reloadedWorld = std::make_unique<World>(false);
+		Registry& reloadedReg = reloadedWorld->GetRegistry();
 		reloadedReg.CreateFromPrefab(reloadedPrefab, entity);
 		return reloadedWorld;
 	}
@@ -554,7 +554,7 @@ namespace
 		return type;
 	}
 
-	UnitTest::Result TestPrefabChanges(World&& initialWorld,
+	UnitTest::Result TestPrefabChanges(std::unique_ptr<World> initialWorld,
 	                                   entt::entity initialEntity,
 	                                   std::vector<PrefabChange> changes,
 	                                   std::function<void(World&, entt::entity)>&& changePrefabInstanceInWorld)
@@ -582,7 +582,7 @@ namespace
 				if (prefabInAssetManager == nullptr)
 				{
 					Prefab testPrefab{ sTestPrefabName };
-					testPrefab.CreateFromEntity(initialWorld, initialEntity);
+					testPrefab.CreateFromEntity(*initialWorld, initialEntity);
 					prefabInAssetManager = AssetManager::Get().AddAsset(std::move(testPrefab));
 				}
 				else
@@ -600,7 +600,7 @@ namespace
 					}
 
 					Prefab newPrefab{ loadInfo };
-					newPrefab.CreateFromEntity(initialWorld, initialEntity);
+					newPrefab.CreateFromEntity(*initialWorld, initialEntity);
 					prefabInAssetManager = AssetManager::Get().AddAsset(std::move(newPrefab));
 				}
 			};
@@ -629,7 +629,7 @@ namespace
 
 			for (const PrefabChange& change : changes)
 			{
-				UnitTest::Result result = change.mMakeChanges(initialWorld, initialEntity);
+				UnitTest::Result result = change.mMakeChanges(*initialWorld, initialEntity);
 
 				if (result != UnitTest::Result::Success)
 				{
@@ -639,8 +639,8 @@ namespace
 				updatePrefab();
 				AssetLoadInfo loadInfo{ serializedLevel };
 				Level level{ loadInfo };
-				World worldWithChangesApplied = level.CreateWorld(false);
-				result = change.mCheckChanges(worldWithChangesApplied, initialEntity);
+				std::unique_ptr<World> worldWithChangesApplied = level.CreateWorld(false);
+				result = change.mCheckChanges(*worldWithChangesApplied, initialEntity);
 
 				if (result != UnitTest::Result::Success)
 				{

--- a/Source/Utilities/Benchmark.cpp
+++ b/Source/Utilities/Benchmark.cpp
@@ -77,8 +77,8 @@ CE::BenchmarkResult CE::BenchMark(std::string_view levelName, BenchmarkParams pa
         return {};
     }
 
-	World world = level->CreateWorld(true);
-    return BenchMark(world, params);
+	std::unique_ptr<World> world = level->CreateWorld(true);
+    return BenchMark(*world, params);
 }
 
 void CE::BenchmarkResult::Print() const

--- a/Source/Utilities/Events.cpp
+++ b/Source/Utilities/Events.cpp
@@ -120,9 +120,6 @@ void CE::EventBase::Define(MetaFunc& metaFunc, const ScriptFunc& scriptFunc, con
 	metaFunc.RedirectFunction([&scriptFunc, script, firstNode = scriptFunc.GetFirstNode().GetValue(), entry = scriptFunc.GetEntryNode().GetValue(), numOfArgsToPass]
 		(MetaFunc::DynamicArgs args, MetaFunc::RVOBuffer rvoBuffer) -> FuncResult
 		{
-			World& world = *args[1].As<World>();
-			World::PushWorld(world);
-
 			// Raii object that manages the lifetime
 			struct ParamDeleter
 			{
@@ -148,9 +145,7 @@ void CE::EventBase::Define(MetaFunc& metaFunc, const ScriptFunc& scriptFunc, con
 				new (&scriptArgs[i + 1])MetaAny(MakeRef(args[i + 3]));
 			}
 
-			FuncResult result = VirtualMachine::Get().ExecuteScriptFunction(std::span<MetaAny>{ scriptArgs, numOfArgsToPass}, rvoBuffer, scriptFunc, firstNode, entry);
-
-			World::PopWorld();
+			FuncResult result = VirtualMachine::Get().ExecuteScriptFunction(std::span{ scriptArgs, numOfArgsToPass}, rvoBuffer, scriptFunc, firstNode, entry);
 			return result;
 		});
 }

--- a/Source/Utilities/Imgui/WorldInspect.cpp
+++ b/Source/Utilities/Imgui/WorldInspect.cpp
@@ -263,7 +263,6 @@ void CE::WorldInspectHelper::DisplayAndTick(const float deltaTime)
 
 		// World will not change anymore
 		World& world = GetWorld();
-		World::PushWorld(world);
 
 		const glm::vec2 fpsCursorPos = { viewportPos.x + mViewportWidth - 60.0f, 0.0f };
 		ImGui::SetCursorPos(fpsCursorPos);
@@ -323,8 +322,6 @@ void CE::WorldInspectHelper::DisplayAndTick(const float deltaTime)
 
 		drawList->ChannelsMerge();
 
-		World::PopWorld();
-
 		if (world.HasRequestedEndPlay())
 		{
 			(void)EndPlay();
@@ -337,7 +334,6 @@ void CE::WorldInspectHelper::DisplayAndTick(const float deltaTime)
 	if (ImGui::BeginChild("HierarchyAndDetailsWindow", { mHierarchyAndDetailsWidth, 0.0f }, false, ImGuiWindowFlags_NoScrollbar))
 	{
 		World& world = GetWorld();
-		World::PushWorld(world);
 
 		ImGui::PushID(2); // Second splitter requires new ID
 		ImGui::Splitter(false, &mHierarchyHeight, &mDetailsHeight);
@@ -350,8 +346,6 @@ void CE::WorldInspectHelper::DisplayAndTick(const float deltaTime)
 		ImGui::BeginChild("WorldDetails", { 0.0f, mDetailsHeight - 5.0f }, false, ImGuiWindowFlags_NoScrollbar);
 		WorldDetails::Display(world, mSelectedEntities);
 		ImGui::EndChild();
-
-		World::PopWorld();
 	}
 
 	ImGui::EndChild();

--- a/Source/Utilities/Imgui/WorldInspect.cpp
+++ b/Source/Utilities/Imgui/WorldInspect.cpp
@@ -54,9 +54,9 @@ namespace CE::Internal
 	static constexpr std::string_view sCopiedEntitiesId = "B1C2FF80";
 }
 
-CE::WorldInspectHelper::WorldInspectHelper(World&& worldThatHasNotYetBegunPlay) :
+CE::WorldInspectHelper::WorldInspectHelper(std::unique_ptr<World> worldThatHasNotYetBegunPlay) :
 	mViewportFrameBuffer(std::make_unique<FrameBuffer>(glm::ivec2(1.f, 1.f))),
-	mWorldBeforeBeginPlay(std::make_unique<World>(std::move(worldThatHasNotYetBegunPlay)))
+	mWorldBeforeBeginPlay(std::move(worldThatHasNotYetBegunPlay))
 {
 	ASSERT(!mWorldBeforeBeginPlay->HasBegunPlay());
 }

--- a/Source/World/Physics.cpp
+++ b/Source/World/Physics.cpp
@@ -150,15 +150,15 @@ CE::MetaType CE::Physics::Reflect()
 	MetaType type = MetaType{ MetaType::T<Physics>{}, "Physics" };
 	type.GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](glm::vec2 centre, float radius, const CollisionRules& filter)
+	type.AddFunc([](const World& world, glm::vec2 centre, float radius, const CollisionRules& filter)
 		{
-			return World::TryGetWorldAtTopOfStack()->GetPhysics().FindAllWithinShape(TransformedDisk{ centre, radius }, filter);
-		}, "Find all bodies in radius", MetaFunc::ExplicitParams<glm::vec2, float, const CollisionRules&>{}, "Centre", "Radius", "Filter").GetProperties().Add(Props::sIsScriptableTag);
+			return world.GetPhysics().FindAllWithinShape(TransformedDisk{ centre, radius }, filter);
+		}, "Find all bodies in radius", MetaFunc::ExplicitParams<const World&, glm::vec2, float, const CollisionRules&>{}, "Centre", "Radius", "Filter").GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](glm::vec2 min, glm::vec2 max, const CollisionRules& filter)
+	type.AddFunc([](const World& world, glm::vec2 min, glm::vec2 max, const CollisionRules& filter)
 		{
-			return World::TryGetWorldAtTopOfStack()->GetPhysics().FindAllWithinShape(TransformedAABB{ min, max }, filter);
-		}, "Find all bodies in box", MetaFunc::ExplicitParams<glm::vec2, glm::vec2, const CollisionRules&>{}, "Min", "Max", "Filter").GetProperties().Add(Props::sIsScriptableTag);
+			return world.GetPhysics().FindAllWithinShape(TransformedAABB{ min, max }, filter);
+		}, "Find all bodies in box", MetaFunc::ExplicitParams<const World&, glm::vec2, glm::vec2, const CollisionRules&>{}, "Min", "Max", "Filter").GetProperties().Add(Props::sIsScriptableTag);
 
 	return type;
 }

--- a/Source/World/World.cpp
+++ b/Source/World/World.cpp
@@ -569,12 +569,10 @@ CE::MetaType CE::World::Reflect()
 			return world->GetScaledDeltaTime();
 		}, "GetScaledDeltaTime", MetaFunc::ExplicitParams<>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
-	type.AddFunc([]()
+	type.AddFunc([](const World& world)
 		{
-			World* world = TryGetWorldAtTopOfStack();
-			ASSERT(world != nullptr);
-			return world->GetRealDeltaTime();
-		}, "GetRealDeltaTime", MetaFunc::ExplicitParams<>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+			return world.GetRealDeltaTime();
+		}, "GetRealDeltaTime", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag);
 
 	return type;
 }


### PR DESCRIPTION
Our weird combination of dependency injection AND using a world stack led to a lot of bugs. Forgetting to push the world could lead to a crash (but only in specific circumstances), and forgetting to pop (which STILL happens in a few places in the main branch)  leads to the stack slowly growing over time.

The world stack made multi-threading difficult, it has been replaced with dependency injection. Script components now hold references to the world, and the world is guaranteed not to move around in memory
