### PR TITLE
Removed explicit params

### DIFF
--- a/Include/Assets/Core/AssetHandle.h
+++ b/Include/Assets/Core/AssetHandle.h
@@ -353,7 +353,7 @@ namespace CE
 			[](const AssetHandle<U>& value, nullptr_t)
 			{
 				return value == nullptr;
-			}, OperatorType::equal, MetaFunc::ExplicitParams<const AssetHandle<U>&, nullptr_t>{});
+			}, OperatorType::equal);
 
 		return refType;
 	}
@@ -405,7 +405,7 @@ namespace CE
 			[](const WeakAssetHandle<U>& value, nullptr_t)
 			{
 				return value == nullptr;
-			}, OperatorType::equal, MetaFunc::ExplicitParams<const WeakAssetHandle<U>&, nullptr_t>{});
+			}, OperatorType::equal);
 
 		return refType;
 	}

--- a/Include/Components/Particles/ParticleUtilities/ParticleUtilitiesImpl.h
+++ b/Include/Components/Particles/ParticleUtilities/ParticleUtilitiesImpl.h
@@ -339,7 +339,7 @@ void CE::ReflectParticleComponentType(MetaType& type)
 			{
 				reg.AddComponent<ComponentType>(newEntity, std::move(*component));
 			}
-		}, Internal::sTransferOwnershipName, MetaFunc::ExplicitParams<Registry&, entt::entity, entt::entity>{});
+		}, Internal::sTransferOwnershipName);
 
 	BindEvent(type, sOnEndPlay, &Internal::OnParticleComponentDestruct);
 	ReflectComponentType<ComponentType>(type);

--- a/Include/Engine/Precomp/Precomp.h
+++ b/Include/Engine/Precomp/Precomp.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#ifdef _MSC_FULL_VER
-static_assert(_MSC_FULL_VER >= 194133923, "https://godbolt.org/z/97rsn91eh");
-#endif
-
 #include <sstream>
 #include <vector>
 #include <span>

--- a/Include/Engine/Precomp/Precomp.h
+++ b/Include/Engine/Precomp/Precomp.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef _MSC_FULL_VER
+static_assert(_MSC_FULL_VER >= 194133923, "https://godbolt.org/z/97rsn91eh");
+#endif
+
 #include <sstream>
 #include <vector>
 #include <span>
@@ -18,6 +22,7 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 #endif
+
 
 #include "entt/entity/component.hpp"
 #include "entt/entity/entity.hpp"

--- a/Include/Meta/Fwd/MetaFuncFwd.h
+++ b/Include/Meta/Fwd/MetaFuncFwd.h
@@ -344,10 +344,10 @@ namespace CE
 		static DynamicArg PackSingle(Arg&& arg);
 
 		template<>
-		STATIC_SPECIALIZATION DynamicArg PackSingle(const MetaAny& other);
+		DynamicArg PackSingle(const MetaAny& other);
 
 		template<>
-		STATIC_SPECIALIZATION DynamicArg PackSingle(MetaAny& other);
+		DynamicArg PackSingle(MetaAny& other);
 
 	private:
 		template<typename Ret, typename... ParamsT>

--- a/Include/Meta/Fwd/MetaFuncFwd.h
+++ b/Include/Meta/Fwd/MetaFuncFwd.h
@@ -163,13 +163,13 @@ namespace CE
 			const Params& parameters);
 
 	private:
-		struct UseContructor{};
+		struct ExplicitlyUseThisConstructor{};
 		explicit MetaFunc(InvokeT&& func,
 			NameOrType&& nameOrOp,
 			std::initializer_list<TypeTraits> paramTypes,
 			std::initializer_list<std::string_view> paramNames,
 			FuncId funcId,
-			UseContructor ctor);
+			ExplicitlyUseThisConstructor ctor);
 
 		MetaFunc(InvokeT&& func,
 			OperatorType op,

--- a/Include/Meta/Fwd/MetaFuncFwd.h
+++ b/Include/Meta/Fwd/MetaFuncFwd.h
@@ -163,33 +163,48 @@ namespace CE
 			const Params& parameters);
 
 	private:
+		struct UseContructor{};
+		explicit MetaFunc(InvokeT&& func,
+			NameOrType&& nameOrOp,
+			std::initializer_list<TypeTraits> paramTypes,
+			std::initializer_list<std::string_view> paramNames,
+			FuncId funcId,
+			UseContructor ctor);
+
 		MetaFunc(InvokeT&& func,
-			NameOrTypeInit nameOrType,
-			Params&& paramsAndReturnAtBack,
+			OperatorType op,
+			std::initializer_list<TypeTraits> paramTypes,
+			std::initializer_list<std::string_view> paramNames,
+			FuncId funcId);
+
+		MetaFunc(InvokeT&& func,
+			std::string_view name,
+			std::initializer_list<TypeTraits> paramTypes,
+			std::initializer_list<std::string_view> paramNames,
 			FuncId funcId);
 
 	public:
-		template<typename Ret, typename... ParamsT, StringLike... ParamAndRetNames>
+		template<typename Ret, typename... ParamsT, typename NameOrOperator, StringLike... ParamAndRetNames>
 		MetaFunc(std::function<Ret(ParamsT...)>&& func,
-			NameOrTypeInit typeOrName,
+			NameOrOperator&& nameOrOp,
 			ParamAndRetNames&&... paramAndRetNames);
 
-		template<typename Functor, StringLike... ParamAndRetNames>
+		template<typename Functor, typename NameOrOperator, StringLike... ParamAndRetNames>
 		MetaFunc(Functor&& functor, 
-			NameOrTypeInit nameOrType, 
+			NameOrOperator&& nameOrType,
 			ParamAndRetNames&&... paramAndRetNames);
 
 		// Mutable member function
-		template<typename Ret, typename Obj, typename... ParamsT, StringLike... ParamAndRetNames>
-		MetaFunc(Ret(Obj::* func)(ParamsT...), NameOrTypeInit typeOrName, ParamAndRetNames&&... paramAndRetNames);
+		template<typename Ret, typename Obj, typename... ParamsT, typename NameOrOperator, StringLike... ParamAndRetNames>
+		MetaFunc(Ret(Obj::* func)(ParamsT...), NameOrOperator&& nameOrOp, ParamAndRetNames&&... paramAndRetNames);
 
 		// Const member function
-		template<typename Ret, typename Obj, typename... ParamsT, StringLike... ParamAndRetNames>
-		MetaFunc(Ret(Obj::* func)(ParamsT...) const, NameOrTypeInit typeOrName, ParamAndRetNames&&... paramAndRetNames);
+		template<typename Ret, typename Obj, typename... ParamsT, typename NameOrOperator, StringLike... ParamAndRetNames>
+		MetaFunc(Ret(Obj::* func)(ParamsT...) const, NameOrOperator&& nameOrOp, ParamAndRetNames&&... paramAndRetNames);
 
 		// Static function
-		template<typename Ret, typename... ParamsT, StringLike... ParamAndRetNames>
-		MetaFunc(Ret(*func)(ParamsT...), NameOrTypeInit typeOrName, ParamAndRetNames&&... paramAndRetNames);
+		template<typename Ret, typename... ParamsT, typename NameOrOperator, StringLike... ParamAndRetNames>
+		MetaFunc(Ret(*func)(ParamsT...), NameOrOperator&& typeOrName, ParamAndRetNames&&... paramAndRetNames);
 
 		MetaFunc(MetaFunc&& other) noexcept;
 		MetaFunc(const MetaFunc&) = delete;

--- a/Include/Meta/Fwd/MetaFuncIdFwd.h
+++ b/Include/Meta/Fwd/MetaFuncIdFwd.h
@@ -8,5 +8,5 @@ namespace CE
 	FuncId MakeFuncId(TypeTraits returnType, const std::vector<TypeTraits>& parameters);
 
 	template<typename T>
-	constexpr FuncId MakeFuncId();
+	consteval FuncId MakeFuncId();
 };

--- a/Include/Meta/Fwd/MetaFuncIdFwd.h
+++ b/Include/Meta/Fwd/MetaFuncIdFwd.h
@@ -8,5 +8,5 @@ namespace CE
 	FuncId MakeFuncId(TypeTraits returnType, const std::vector<TypeTraits>& parameters);
 
 	template<typename T>
-	consteval FuncId MakeFuncId();
+	CONSTEVAL FuncId MakeFuncId();
 };

--- a/Include/Meta/Fwd/MetaReflectFwd.h
+++ b/Include/Meta/Fwd/MetaReflectFwd.h
@@ -48,25 +48,12 @@ namespace CE
 		void RegisterReflectFunc(TypeId typeId, MetaType(*reflectFunc)());
 
 		template<typename T>
+		bool InitStaticDummy();
+
+		template<typename T>
 		struct ReflectAtStartup
 		{
-			inline static bool sDummy = []
-				{
-					static_assert(!sHasExternalReflect<T> || !sHasInternalReflect<T>, "Both an internal and external reflect function.");
-					static_assert(sHasExternalReflect<T> || sHasInternalReflect<T>,
-						R"(No external or internal reflect function. You need to make sure the Reflect function is included from wherever you are trying to reflect it.
-If you are trying to reflect an std::vector<AssetHandle<Material>>, you need to include AssetHandle.h, Material.h and ReflectVector.h.)");
-
-					if constexpr (sHasInternalReflect<T>)
-					{
-						Internal::RegisterReflectFunc(MakeTypeId<T>(), ReflectAccess::GetReflectFunc<T>());
-					}
-					else if constexpr (sHasExternalReflect<T>)
-					{
-						Internal::RegisterReflectFunc(MakeTypeId<T>(), &Reflector<T>::Reflect);
-					}
-					return true;
-				}();
+			inline static bool sDummy = InitStaticDummy<T>();
 		};
 	}
 

--- a/Include/Meta/Fwd/MetaTypeFwd.h
+++ b/Include/Meta/Fwd/MetaTypeFwd.h
@@ -95,10 +95,12 @@ namespace CE
 			typevec2.AddField(&vec2::z, "Z");
 		*/
 		template<typename... Args>
-		MetaField& AddField(Args&& ...args);
+		MetaField& AddField(Args&&... args);
+
+		MetaField& AddField(MetaField&& field);
 
 		/*
-		Constructs a MetaFunc in place using the provided Args.
+		Constructs a MetaFunc using the provided Args.
 
 		Example:
 			typeFloat.AddFunc(&sinf, "Sin");
@@ -107,6 +109,8 @@ namespace CE
 		*/
 		template<typename FuncPtr, typename... Args>
 		MetaFunc& AddFunc(FuncPtr&& funcPtr, MetaFunc::NameOrTypeInit nameOrType, Args&& ...args);
+
+		MetaFunc& AddFunc(MetaFunc&& func);
 
 		/*
 		Add a baseclass. This function does not check if you ACTUALLY derive

--- a/Include/Meta/Fwd/MetaTypeFwd.h
+++ b/Include/Meta/Fwd/MetaTypeFwd.h
@@ -107,8 +107,8 @@ namespace CE
 
 			// For more examples, take a look at the comments documenting the MetaFunc class
 		*/
-		template<typename FuncPtr, typename... Args>
-		MetaFunc& AddFunc(FuncPtr&& funcPtr, MetaFunc::NameOrTypeInit nameOrType, Args&& ...args);
+		template<typename... Args>
+		MetaFunc& AddFunc(Args&& ...args);
 
 		MetaFunc& AddFunc(MetaFunc&& func);
 

--- a/Include/Meta/Fwd/MetaTypeIdFwd.h
+++ b/Include/Meta/Fwd/MetaTypeIdFwd.h
@@ -5,8 +5,8 @@ namespace CE
 	using TypeId = uint32;
 
 	template<typename T>
-	consteval TypeId MakeTypeId();
+	CONSTEVAL TypeId MakeTypeId();
 
 	template<typename T>
-	consteval std::string_view MakeTypeName();
+	CONSTEVAL std::string_view MakeTypeName();
 }

--- a/Include/Meta/Fwd/MetaTypeIdFwd.h
+++ b/Include/Meta/Fwd/MetaTypeIdFwd.h
@@ -5,8 +5,8 @@ namespace CE
 	using TypeId = uint32;
 
 	template<typename T>
-	constexpr TypeId MakeTypeId();
+	consteval TypeId MakeTypeId();
 
 	template<typename T>
-	constexpr std::string_view MakeTypeName();
+	consteval std::string_view MakeTypeName();
 }

--- a/Include/Meta/Fwd/MetaTypeTraitsFwd.h
+++ b/Include/Meta/Fwd/MetaTypeTraitsFwd.h
@@ -86,14 +86,14 @@ namespace CE
 	constexpr bool CanFormBeNullable(TypeForm form);
 
 	template<typename T>
-	consteval TypeTraits MakeTypeTraits();
+	CONSTEVAL TypeTraits MakeTypeTraits();
 
 	template<typename T>
-	consteval TypeInfo MakeTypeInfo();
+	CONSTEVAL TypeInfo MakeTypeInfo();
 
 	template<typename T>
-	consteval TypeForm MakeTypeForm();
+	CONSTEVAL TypeForm MakeTypeForm();
 
 	template<typename T>
-	consteval TypeId MakeStrippedTypeId();
+	CONSTEVAL TypeId MakeStrippedTypeId();
 }

--- a/Include/Meta/Fwd/MetaTypeTraitsFwd.h
+++ b/Include/Meta/Fwd/MetaTypeTraitsFwd.h
@@ -86,14 +86,14 @@ namespace CE
 	constexpr bool CanFormBeNullable(TypeForm form);
 
 	template<typename T>
-	constexpr TypeTraits MakeTypeTraits();
+	consteval TypeTraits MakeTypeTraits();
 
 	template<typename T>
-	constexpr TypeInfo MakeTypeInfo();
+	consteval TypeInfo MakeTypeInfo();
 
 	template<typename T>
-	constexpr TypeForm MakeTypeForm();
+	consteval TypeForm MakeTypeForm();
 
 	template<typename T>
-	constexpr TypeId MakeStrippedTypeId();
+	consteval TypeId MakeStrippedTypeId();
 }

--- a/Include/Meta/Impl/MetaFuncIdImpl.h
+++ b/Include/Meta/Impl/MetaFuncIdImpl.h
@@ -38,7 +38,7 @@ namespace CE::Internal
 namespace CE
 {
 	template<typename T>
-	constexpr FuncId MakeFuncId()
+	consteval FuncId MakeFuncId()
 	{
 		return Internal::FunctionHasher<T>::value();
 	}

--- a/Include/Meta/Impl/MetaFuncIdImpl.h
+++ b/Include/Meta/Impl/MetaFuncIdImpl.h
@@ -38,7 +38,7 @@ namespace CE::Internal
 namespace CE
 {
 	template<typename T>
-	consteval FuncId MakeFuncId()
+	CONSTEVAL FuncId MakeFuncId()
 	{
 		return Internal::FunctionHasher<T>::value();
 	}

--- a/Include/Meta/Impl/MetaFuncImpl.h
+++ b/Include/Meta/Impl/MetaFuncImpl.h
@@ -28,9 +28,9 @@ namespace CE::Internal
 	static constexpr bool ValidNumOfParamsV = ValidNumOfParams<FuncSig>::template Value<ParamAndRetNames...>();
 }
 
-template<typename Ret, typename... ParamsT, CE::StringLike... ParamAndRetNames>
+template<typename Ret, typename... ParamsT, typename NameOrOperator, CE::StringLike... ParamAndRetNames>
 CE::MetaFunc::MetaFunc(std::function<Ret(ParamsT...)>&& func,
-	const NameOrTypeInit typeOrName,
+	NameOrOperator&& nameOrOp,
 	ParamAndRetNames&&... paramAndRetNames) :
 	MetaFunc(
 		InvokeT
@@ -40,50 +40,32 @@ CE::MetaFunc::MetaFunc(std::function<Ret(ParamsT...)>&& func,
 				return DefaultInvoke<Ret, ParamsT...>(func, args, buffer);
 			}
 		},
-		typeOrName,
-		[&]
-		{
-			std::array<TypeTraits, sizeof...(ParamsT) + 1> paramTraits{ MakeTypeTraits<ParamsT>()..., MakeTypeTraits<Ret>() };
-			std::array<std::string, sizeof...(ParamAndRetNames)> paramNames{ std::forward<ParamAndRetNames>(paramAndRetNames)... };
-
-			std::vector<MetaFuncNamedParam> namedParams(sizeof...(ParamsT) + 1);
-
-			for (size_t i = 0; i < sizeof...(ParamsT) + 1; i++)
-			{
-				namedParams[i].mTypeTraits = paramTraits[i];
-			}
-
-			for (size_t i = 0; i < sizeof...(ParamAndRetNames); i++)
-			{
-				namedParams[i].mName = std::move(paramNames[i]);
-			}
-
-			return namedParams;
-		}(),
-			MakeFuncId<Ret(ParamsT...)>())
+		std::forward<NameOrOperator>(nameOrOp),
+		std::initializer_list<TypeTraits>{ MakeTypeTraits<ParamsT>()..., MakeTypeTraits<Ret>() },
+		std::initializer_list<std::string_view>{ std::forward<ParamAndRetNames>(paramAndRetNames)...},
+		MakeFuncId<Ret(ParamsT...)>())
 {
 	static_assert(Internal::ValidNumOfParamsV<Ret(ParamsT...), ParamAndRetNames...>, "Too many names provided; First one name for each parameter, and if the function does not return void, one for the return value.");
 }
 
-template <typename Functor, CE::StringLike ... ParamAndRetNames>
-CE::MetaFunc::MetaFunc(Functor&& functor, NameOrTypeInit nameOrType, ParamAndRetNames&&... paramAndRetNames) :
-	MetaFunc(std::function{ std::forward<Functor>(functor) }, nameOrType, std::forward<ParamAndRetNames>(paramAndRetNames)...)
-{
-}
-
-template <typename Ret, typename Obj, typename ... ParamsT, CE::StringLike ... ParamAndRetNames>
-CE::MetaFunc::MetaFunc(Ret(Obj::* func)(ParamsT...), const NameOrTypeInit typeOrName, ParamAndRetNames&&... paramAndRetNames) :
-	MetaFunc(std::function<Ret(Obj&, ParamsT...)>{ func }, typeOrName, std::forward<ParamAndRetNames>(paramAndRetNames)...)
+template <typename Functor, typename NameOrOperator, CE::StringLike ... ParamAndRetNames>
+CE::MetaFunc::MetaFunc(Functor&& functor, NameOrOperator&& nameOrOp, ParamAndRetNames&&... paramAndRetNames) :
+	MetaFunc(std::function{ std::forward<Functor>(functor) }, std::forward<NameOrOperator>(nameOrOp), std::forward<ParamAndRetNames>(paramAndRetNames)...)
 {}
 
-template <typename Ret, typename Obj, typename ... ParamsT, CE::StringLike ... ParamAndRetNames>
-CE::MetaFunc::MetaFunc(Ret(Obj::* func)(ParamsT...) const, const NameOrTypeInit typeOrName, ParamAndRetNames&&... paramAndRetNames) :
-	MetaFunc(std::function<Ret(const Obj&, ParamsT...)>{ func }, typeOrName, std::forward<ParamAndRetNames>(paramAndRetNames)...)
+template <typename Ret, typename Obj, typename ... ParamsT, typename NameOrOperator, CE::StringLike ... ParamAndRetNames>
+CE::MetaFunc::MetaFunc(Ret(Obj::* func)(ParamsT...), NameOrOperator&& nameOrOp, ParamAndRetNames&&... paramAndRetNames) :
+	MetaFunc(std::function<Ret(Obj&, ParamsT...)>{ func }, std::forward<NameOrOperator>(nameOrOp), std::forward<ParamAndRetNames>(paramAndRetNames)...)
 {}
 
-template <typename Ret, typename ... ParamsT, CE::StringLike ... ParamAndRetNames>
-CE::MetaFunc::MetaFunc(Ret(*func)(ParamsT...), const NameOrTypeInit typeOrName, ParamAndRetNames&&... paramAndRetNames) :
-	MetaFunc(std::function<Ret(ParamsT...)>{ func }, typeOrName, std::forward<ParamAndRetNames>(paramAndRetNames)...)
+template <typename Ret, typename Obj, typename ... ParamsT, typename NameOrOperator, CE::StringLike ... ParamAndRetNames>
+CE::MetaFunc::MetaFunc(Ret(Obj::* func)(ParamsT...) const, NameOrOperator&& nameOrOp, ParamAndRetNames&&... paramAndRetNames) :
+	MetaFunc(std::function<Ret(const Obj&, ParamsT...)>{ func }, std::forward<NameOrOperator>(nameOrOp), std::forward<ParamAndRetNames>(paramAndRetNames)...)
+{}
+
+template <typename Ret, typename ... ParamsT, typename NameOrOperator, CE::StringLike ... ParamAndRetNames>
+CE::MetaFunc::MetaFunc(Ret(*func)(ParamsT...), NameOrOperator&& nameOrOp, ParamAndRetNames&&... paramAndRetNames) :
+	MetaFunc(std::function<Ret(ParamsT...)>{ func }, std::forward<NameOrOperator>(nameOrOp), std::forward<ParamAndRetNames>(paramAndRetNames)...)
 {}
 
 namespace CE::Internal

--- a/Include/Meta/Impl/MetaReflectImpl.h
+++ b/Include/Meta/Impl/MetaReflectImpl.h
@@ -8,3 +8,22 @@
 #include "Meta/ReflectedTypes/STD/ReflectString.h"
 #include "Meta/ReflectedTypes/ReflectENTT.h"
 #include "Meta/ReflectedTypes/ReflectNull.h"
+
+template<typename T>
+bool CE::Internal::InitStaticDummy()
+{
+	static_assert(!sHasExternalReflect<T> || !sHasInternalReflect<T>, "Both an internal and external reflect function.");
+	static_assert(sHasExternalReflect<T> || sHasInternalReflect<T>,
+		R"(No external or internal reflect function. You need to make sure the Reflect function is included from wherever you are trying to reflect it.
+If you are trying to reflect an std::vector<AssetHandle<Material>>, you need to include AssetHandle.h, Material.h and ReflectVector.h.)");
+
+	if constexpr (sHasInternalReflect<T>)
+	{
+		Internal::RegisterReflectFunc(MakeTypeId<T>(), ReflectAccess::GetReflectFunc<T>());
+	}
+	else if constexpr (sHasExternalReflect<T>)
+	{
+		Internal::RegisterReflectFunc(MakeTypeId<T>(), &Reflector<T>::Reflect);
+	}
+	return true;
+}

--- a/Include/Meta/Impl/MetaTypeIdImpl.h
+++ b/Include/Meta/Impl/MetaTypeIdImpl.h
@@ -2,13 +2,13 @@
 #include "Meta/Fwd/MetaTypeIdFwd.h"
 
 template<typename T>
-consteval CE::TypeId CE::MakeTypeId()
+CONSTEVAL CE::TypeId CE::MakeTypeId()
 {
 	return entt::type_hash<T>::value();
 }
 
 template<typename T>
-consteval std::string_view CE::MakeTypeName()
+CONSTEVAL std::string_view CE::MakeTypeName()
 {
 	return entt::type_name<T>::value();
 }

--- a/Include/Meta/Impl/MetaTypeIdImpl.h
+++ b/Include/Meta/Impl/MetaTypeIdImpl.h
@@ -2,13 +2,13 @@
 #include "Meta/Fwd/MetaTypeIdFwd.h"
 
 template<typename T>
-constexpr CE::TypeId CE::MakeTypeId()
+consteval CE::TypeId CE::MakeTypeId()
 {
 	return entt::type_hash<T>::value();
 }
 
 template<typename T>
-constexpr std::string_view CE::MakeTypeName()
+consteval std::string_view CE::MakeTypeName()
 {
 	return entt::type_name<T>::value();
 }

--- a/Include/Meta/Impl/MetaTypeImpl.h
+++ b/Include/Meta/Impl/MetaTypeImpl.h
@@ -65,10 +65,10 @@ CE::MetaType::MetaType(T<TypeT>, const std::string_view name, Args&&... args) :
 		}, OperatorType::destructor);
 }
 
-template<typename FuncPtr, typename... Args>
-CE::MetaFunc& CE::MetaType::AddFunc(FuncPtr&& funcPtr, const MetaFunc::NameOrTypeInit nameOrType, Args&& ...args)
+template<typename... Args>
+CE::MetaFunc& CE::MetaType::AddFunc(Args&& ...args)
 {
-	return AddFunc(MetaFunc{ std::forward<FuncPtr>(funcPtr), nameOrType, std::forward<Args>(args)... });
+	return AddFunc(MetaFunc{ std::forward<Args>(args)... });
 }
 
 template<typename ...Args>

--- a/Include/Meta/Impl/MetaTypeTraitsImpl.h
+++ b/Include/Meta/Impl/MetaTypeTraitsImpl.h
@@ -44,13 +44,13 @@ constexpr bool CE::CanFormBeNullable(TypeForm form)
 }
 
 template<typename T>
-consteval CE::TypeTraits CE::MakeTypeTraits()
+CONSTEVAL CE::TypeTraits CE::MakeTypeTraits()
 {
 	return { MakeStrippedTypeId<T>(), MakeTypeForm<T>() };
 }
 
 template <typename TNonStripped>
-consteval CE::TypeInfo CE::MakeTypeInfo()
+CONSTEVAL CE::TypeInfo CE::MakeTypeInfo()
 {
 	using StrippedT = std::remove_const_t<std::remove_reference_t<std::remove_pointer_t<TNonStripped>>>;
 
@@ -87,7 +87,7 @@ consteval CE::TypeInfo CE::MakeTypeInfo()
 }
 
 template <typename T>
-consteval CE::TypeForm CE::MakeTypeForm()
+CONSTEVAL CE::TypeForm CE::MakeTypeForm()
 {
 	if constexpr (std::is_rvalue_reference_v<T>)
 	{
@@ -111,7 +111,7 @@ consteval CE::TypeForm CE::MakeTypeForm()
 }
 
 template <typename T>
-consteval CE::TypeId CE::MakeStrippedTypeId()
+CONSTEVAL CE::TypeId CE::MakeStrippedTypeId()
 {
 	return MakeTypeId<std::remove_const_t<std::remove_reference_t<std::remove_pointer_t<T>>>>();
 }

--- a/Include/Meta/Impl/MetaTypeTraitsImpl.h
+++ b/Include/Meta/Impl/MetaTypeTraitsImpl.h
@@ -44,13 +44,13 @@ constexpr bool CE::CanFormBeNullable(TypeForm form)
 }
 
 template<typename T>
-constexpr CE::TypeTraits CE::MakeTypeTraits()
+consteval CE::TypeTraits CE::MakeTypeTraits()
 {
 	return { MakeStrippedTypeId<T>(), MakeTypeForm<T>() };
 }
 
 template <typename TNonStripped>
-constexpr CE::TypeInfo CE::MakeTypeInfo()
+consteval CE::TypeInfo CE::MakeTypeInfo()
 {
 	using StrippedT = std::remove_const_t<std::remove_reference_t<std::remove_pointer_t<TNonStripped>>>;
 
@@ -87,7 +87,7 @@ constexpr CE::TypeInfo CE::MakeTypeInfo()
 }
 
 template <typename T>
-constexpr CE::TypeForm CE::MakeTypeForm()
+consteval CE::TypeForm CE::MakeTypeForm()
 {
 	if constexpr (std::is_rvalue_reference_v<T>)
 	{
@@ -111,7 +111,7 @@ constexpr CE::TypeForm CE::MakeTypeForm()
 }
 
 template <typename T>
-constexpr CE::TypeId CE::MakeStrippedTypeId()
+consteval CE::TypeId CE::MakeStrippedTypeId()
 {
 	return MakeTypeId<std::remove_const_t<std::remove_reference_t<std::remove_pointer_t<T>>>>();
 }

--- a/Include/Meta/ReflectedTypes/STD/ReflectVector.h
+++ b/Include/Meta/ReflectedTypes/STD/ReflectVector.h
@@ -4,31 +4,6 @@
 #include "Meta/MetaType.h"
 #include "Utilities/Reflect/ReflectFieldType.h"
 
-//namespace CE::Internal
-//{
-//	template<typename T, typename Arg> std::false_type operator<(const T&, const Arg&);
-//	template<typename T, typename Arg> std::false_type operator==(const T&, const Arg&);
-//	template<typename T, typename Arg> std::false_type operator!=(const T&, const Arg&);
-//
-//	template<typename T, typename Arg = T>
-//	struct LessThanExists
-//	{
-//		enum { value = !std::is_same<decltype(std::declval<T>() < std::declval<Arg>()), std::false_type>::value };
-//	};
-//
-//	template<typename T, typename Arg = T>
-//	struct EqualExists
-//	{
-//		enum { value = !std::is_same<decltype(std::declval<T>() == std::declval<Arg>()), std::false_type>::value };
-//	};
-//
-//	template<typename T, typename Arg = T>
-//	struct NotEqualExists
-//	{
-//		enum { value = !std::is_same<decltype(std::declval<T>() != std::declval<Arg>()), std::false_type>::value };
-//	};
-//}
-
 template<typename T>
 struct Reflector<std::vector<T>>
 {
@@ -86,7 +61,7 @@ struct Reflector<std::vector<T>>
 
 		}
 
-		arrayType.AddFunc(&std::vector<T>::clear, "Clear").GetProperties().Add(Props::sIsScriptableTag);
+		arrayType.AddFunc(static_cast<void(std::vector<T>::*)()>(&std::vector<T>::clear), "Clear").GetProperties().Add(Props::sIsScriptableTag);
 
 		arrayType.AddFunc(static_cast<void(std::vector<T>::*)(const T&)>(&std::vector<T>::push_back), "Add to end").GetProperties().Add(Props::sIsScriptableTag);
 
@@ -100,7 +75,7 @@ struct Reflector<std::vector<T>>
 				{
 					LOG(LogScripting, Warning, "Called PopBack on empty array");
 				}
-			}, "Remove from end", MetaFunc::ExplicitParams<std::vector<T>&>{}).GetProperties().Add(Props::sIsScriptableTag);
+			}, "Remove from end").GetProperties().Add(Props::sIsScriptableTag);
 
 		arrayType.AddFunc([](std::vector<T>& v, const int32& newSize)
 			{
@@ -110,43 +85,22 @@ struct Reflector<std::vector<T>>
 				}
 
 				v.resize(static_cast<size_t>(std::max(newSize, 0)));
-			}, "Resize", MetaFunc::ExplicitParams<std::vector<T>&, const int32&>{}).GetProperties().Add(Props::sIsScriptableTag);
+			}, "Resize").GetProperties().Add(Props::sIsScriptableTag);
 
 		arrayType.AddFunc([](const std::vector<T>& v) -> int32
 			{
 				return static_cast<int32>(v.size());
-			}, "Get size", MetaFunc::ExplicitParams<const std::vector<T>&>{}).GetProperties().Add(Props::sIsScriptableTag);
-
-		//if constexpr (Internal::LessThanExists<T>::value)
-		//{
-		//	arrayType.AddFunc([](std::vector<T>& v)
-		//		{
-		//			std::sort(v.begin(), v.end());
-		//		}, "Sort", MetaFunc::ExplicitParams<std::vector<T>&>{}).GetProperties().Add(Props::sIsScriptableTag);
-		//}
+			}, "Get size").GetProperties().Add(Props::sIsScriptableTag);
 
 		arrayType.AddFunc([](std::vector<T>& v)
 			{
 				std::reverse(v.begin(), v.end());
-			}, "Reverse", MetaFunc::ExplicitParams<std::vector<T>&>{}).GetProperties().Add(Props::sIsScriptableTag);
-
-
-		//if constexpr (Internal::EqualExists<T>::value)
-		//{
-		//	arrayType.AddFunc(std::equal_to<std::vector<T>>(), OperatorType::equal,
-		//		MetaFunc::ExplicitParams<const std::vector<T>&, const std::vector<T>&>{}).GetProperties().Add(Props::sIsScriptableTag);
-		//}
-
-		//if constexpr (Internal::NotEqualExists<T>::value)
-		//{
-		//	arrayType.AddFunc(std::not_equal_to<std::vector<T>>(), OperatorType::inequal,
-		//		MetaFunc::ExplicitParams<const std::vector<T>&, const std::vector<T>&>{}).GetProperties().Add(Props::sIsScriptableTag);
-		//}
+			}, "Reverse").GetProperties().Add(Props::sIsScriptableTag);
 
 		arrayType.AddFunc([](std::vector<T>& v, const std::vector<T>& other)
 			{
 				v.insert(v.end(), other.begin(), other.end());
-			}, "Combine", MetaFunc::ExplicitParams<std::vector<T>&, const std::vector<T>&>{}).GetProperties().Add(Props::sIsScriptableTag);
+			}, "Combine").GetProperties().Add(Props::sIsScriptableTag);
 
 
 		ReflectFieldType<std::vector<T>>(arrayType);

--- a/Include/Utilities/CPP20/STDAliases.h
+++ b/Include/Utilities/CPP20/STDAliases.h
@@ -1,19 +1,15 @@
 #pragma once
 
 #ifdef _MSC_VER 
-
 #pragma warning(push)
 #pragma warning(disable : 4702) // Unreachable code
-
 #endif // _MSC_VER
 
 #define FMT_HEADER_ONLY
 #include "fmt/format.h"
 
 #ifdef _MSC_VER
-
 #pragma warning(pop)
-
 #endif // _MSC_VER
 
 namespace CE
@@ -25,24 +21,17 @@ namespace CE
 	}
 }
 
-#if __cplusplus >= 202002L // If we have C++20 or higher
+// Older versions of MSVC did not implement CONSTEVAL correctly,
+// see compiler explorer: https://godbolt.org/z/97rsn91eh
+// By using this macro, older versions will still compile,
+// they'll just do more work at runtime.
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER < 194133923
+#define CONSTEVAL constexpr
+#else
+#define CONSTEVAL consteval
+#endif
 
 #define UNLIKELY [[unlikely]]
 #define LIKELY [[likely]]
-
-#define STATIC_SPECIALIZATION 
-
-#else // If we don't have C++20
-
-#define UNLIKELY
-#define LIKELY
-
-#ifdef __clang__
-#define STATIC_SPECIALIZATION
-#else
-#define STATIC_SPECIALIZATION static
-#endif
-#endif
-
 #define ENGINE_ALLOCA _alloca
 #define FORCE_INLINE __forceinline

--- a/Include/Utilities/Reflect/ReflectAssetType.h
+++ b/Include/Utilities/Reflect/ReflectAssetType.h
@@ -20,8 +20,7 @@ namespace CE
 			{
 				ret = GetThumbNailImpl<T>(StaticAssetHandleCast<T>(asset));
 			},
-			Internal::sGetThumbnailFuncName,
-			MetaFunc::ExplicitParams<GetThumbnailRet&, const WeakAssetHandle<>&>{});
+			Internal::sGetThumbnailFuncName);
 #endif // EDITOR
 
 		// Will ensure the array and ptr types are reflected at startup

--- a/Include/Utilities/Reflect/ReflectFieldType.h
+++ b/Include/Utilities/Reflect/ReflectFieldType.h
@@ -15,15 +15,15 @@ namespace CE
 		type.AddFunc(&ShowInspectUI<T>, sShowInspectUIFuncName.StringView());
 #endif // EDITOR
 
-		type.AddFunc(&BinaryGSONMember::operator<<<T>, sSerializeMemberFuncName.StringView());
-		type.AddFunc(&BinaryGSONMember::operator>><T>, sDeserializeMemberFuncName.StringView());
+		type.AddFunc([](BinaryGSONMember& m, const T& v) { m << v; }, sSerializeMemberFuncName.StringView());
+		type.AddFunc([](const BinaryGSONMember& m, T& v) { m >> v; }, sDeserializeMemberFuncName.StringView());
 		
 		if (type.TryGetFunc(OperatorType::equal, MakeFuncId<bool(const T&, const T&)>()) != nullptr)
 		{
 			return;
 		}
 
-		MetaProps& equalFuncProps = type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties();
+		MetaProps& equalFuncProps = type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties();
 
 		if (type.GetProperties().Has(Props::sIsScriptableTag))
 		{

--- a/Source/BasicDataTypes/Bezier.cpp
+++ b/Source/BasicDataTypes/Bezier.cpp
@@ -82,7 +82,7 @@ CE::MetaType CE::Bezier::Reflect()
 	type.AddFunc([](const Bezier& bezier, float t1, float t2)
 		{
 			return bezier.GetSurfaceAreaBetween(t1, t2, 0.05f);
-		}, "GetSurfaceAreaBetween", MetaFunc::ExplicitParams<const Bezier&, float, float>{}, "", "T1", "T2").GetProperties().Add(Props::sIsScriptableTag);
+		}, "GetSurfaceAreaBetween", "", "T1", "T2").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(&Bezier::GetValueAt, "GetValueAt", "", "Time").GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<Bezier>(type);

--- a/Source/Components/AudioEmitterComponent.cpp
+++ b/Source/Components/AudioEmitterComponent.cpp
@@ -224,7 +224,7 @@ CE::MetaType CE::AudioEmitterComponent::Reflect()
 	type.AddFunc([](AudioEmitterComponent& audioEmitter)
 		{
 			audioEmitter.Play(audioEmitter.mSound, audioEmitter.mVolume, audioEmitter.mPitch);
-		}, "Play Sound", MetaFunc::ExplicitParams<AudioEmitterComponent&>{}
+		}, "Play Sound"
 		).GetProperties().Add(Props::sCallFromEditorTag);
 
 	type.AddFunc(&AudioEmitterComponent::StopAll, "StopAll").GetProperties().Add(Props::sCallFromEditorTag);
@@ -232,7 +232,7 @@ CE::MetaType CE::AudioEmitterComponent::Reflect()
 	type.AddFunc([](AudioEmitterComponent& audioEmitter)
 			{
 				audioEmitter.SetChannelGroup(audioEmitter.mGroup);
-			}, "Set Channel Group", MetaFunc::ExplicitParams<AudioEmitterComponent&>{}
+			}, "Set Channel Group"
 			).GetProperties().Add(Props::sCallFromEditorTag);
 #endif // EDITOR
 

--- a/Source/Components/Physics2D/PhysicsBody2DComponent.cpp
+++ b/Source/Components/Physics2D/PhysicsBody2DComponent.cpp
@@ -101,8 +101,8 @@ CE::MetaType Reflector<CE::CollisionLayer>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "CollisionLayer" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 	ReflectFieldType<T>(type);
 
 	return type;

--- a/Source/Components/TransformComponent.cpp
+++ b/Source/Components/TransformComponent.cpp
@@ -467,7 +467,7 @@ CE::MetaType CE::TransformComponent::Reflect()
 			}
 
 			return owners;
-		}, "GetChildren", MetaFunc::ExplicitParams<const TransformComponent&>{}, "").GetProperties().Add(Props::sIsScriptableTag);
+		}, "GetChildren", "").GetProperties().Add(Props::sIsScriptableTag);
 
 
 	type.AddFunc(&TransformComponent::IsOrphan, "IsOrphan", "").GetProperties().Add(Props::sIsScriptableTag);

--- a/Source/Core/Audio.cpp
+++ b/Source/Core/Audio.cpp
@@ -70,8 +70,8 @@ CE::MetaType Reflector<CE::Audio::Group>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Group" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 	ReflectFieldType<T>(type);
 
 	return type;

--- a/Source/Core/Input.cpp
+++ b/Source/Core/Input.cpp
@@ -10,22 +10,22 @@ CE::MetaType CE::Input::Reflect()
 	MetaType type = MetaType{ MetaType::T<Input>{}, "Input" };
 	type.GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](int gamepadID, GamepadAxis axis) { return Input::Get().GetGamepadAxis(gamepadID, axis); }, "GetGamepadAxis", MetaFunc::ExplicitParams<int, GamepadAxis>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](int gamepadID, GamepadButton button) { return Input::Get().IsGamepadButtonHeld(gamepadID, button);}, "IsGamepadButtonHeld", MetaFunc::ExplicitParams<int, GamepadButton>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](int gamepadID, GamepadButton button) { return Input::Get().WasGamepadButtonPressed(gamepadID, button); }, "WasGamepadButtonPressed", MetaFunc::ExplicitParams<int, GamepadButton>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](int gamepadID, GamepadButton button) { return Input::Get().WasGamepadButtonReleased(gamepadID, button); }, "WasGamepadButtonReleased", MetaFunc::ExplicitParams<int, GamepadButton>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](int gamepadID) { return Input::Get().IsGamepadAvailable(gamepadID); }, "IsGamepadAvailable", MetaFunc::ExplicitParams<int>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](int gamepadID, GamepadAxis axis) { return Input::Get().GetGamepadAxis(gamepadID, axis); }, "GetGamepadAxis").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](int gamepadID, GamepadButton button) { return Input::Get().IsGamepadButtonHeld(gamepadID, button);}, "IsGamepadButtonHeld").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](int gamepadID, GamepadButton button) { return Input::Get().WasGamepadButtonPressed(gamepadID, button); }, "WasGamepadButtonPressed").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](int gamepadID, GamepadButton button) { return Input::Get().WasGamepadButtonReleased(gamepadID, button); }, "WasGamepadButtonReleased").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](int gamepadID) { return Input::Get().IsGamepadAvailable(gamepadID); }, "IsGamepadAvailable").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc([] { return Input::Get().IsMouseAvailable(); }, "IsMouseAvailable").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](MouseButton button) { return Input::Get().IsMouseButtonHeld(button); }, "IsMouseButtonHeld", MetaFunc::ExplicitParams<MouseButton>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](MouseButton button) { return Input::Get().WasMouseButtonPressed(button); }, "WasMouseButtonPressed", MetaFunc::ExplicitParams<MouseButton>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](MouseButton button) { return Input::Get().WasMouseButtonReleased(button); }, "WasMouseButtonReleased", MetaFunc::ExplicitParams<MouseButton>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](MouseButton button) { return Input::Get().IsMouseButtonHeld(button); }, "IsMouseButtonHeld").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](MouseButton button) { return Input::Get().WasMouseButtonPressed(button); }, "WasMouseButtonPressed").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](MouseButton button) { return Input::Get().WasMouseButtonReleased(button); }, "WasMouseButtonReleased").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc([] { return Input::Get().GetMousePosition(); }, "GetMousePosition").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc([] { return Input::Get().GetMouseWheel(); }, "GetMouseWheel").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc([] { return Input::Get().IsKeyboardAvailable(); }, "IsKeyboardAvailable").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](KeyboardKey button) { return Input::Get().IsKeyboardKeyHeld(button); }, "IsKeyboardKeyHeld", MetaFunc::ExplicitParams<KeyboardKey>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](KeyboardKey button) { return Input::Get().WasKeyboardKeyPressed(button); }, "WasKeyboardKeyPressed", MetaFunc::ExplicitParams<KeyboardKey>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](KeyboardKey button) { return Input::Get().WasKeyboardKeyReleased(button); }, "WasKeyboardKeyReleased", MetaFunc::ExplicitParams<KeyboardKey>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](KeyboardKey positive, KeyboardKey negative) { return Input::Get().GetKeyboardAxis(positive, negative); }, "GetKeyboardAxis", MetaFunc::ExplicitParams<KeyboardKey, KeyboardKey>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](KeyboardKey button) { return Input::Get().IsKeyboardKeyHeld(button); }, "IsKeyboardKeyHeld").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](KeyboardKey button) { return Input::Get().WasKeyboardKeyPressed(button); }, "WasKeyboardKeyPressed").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](KeyboardKey button) { return Input::Get().WasKeyboardKeyReleased(button); }, "WasKeyboardKeyReleased").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](KeyboardKey positive, KeyboardKey negative) { return Input::Get().GetKeyboardAxis(positive, negative); }, "GetKeyboardAxis").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc([] { return Input::Get().HasFocus(); }, "HasFocus").GetProperties().Add(Props::sIsScriptableTag);
 
 	return type;
@@ -38,8 +38,8 @@ CE::MetaType Reflector<CE::Input::KeyboardKey>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "KeyboardKey" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 	ReflectFieldType<T>(type);
 
 	return type;
@@ -52,8 +52,8 @@ CE::MetaType Reflector<CE::Input::GamepadAxis>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "GamepadAxis" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 	ReflectFieldType<T>(type);
 
 	return type;
@@ -66,8 +66,8 @@ CE::MetaType Reflector<CE::Input::GamepadButton>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "GamepadButton" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 	ReflectFieldType<T>(type);
 
 	return type;
@@ -80,8 +80,8 @@ CE::MetaType Reflector<CE::Input::MouseButton>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "MouseButton" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 	ReflectFieldType<T>(type);
 
 	return type;

--- a/Source/Meta/MetaField.cpp
+++ b/Source/Meta/MetaField.cpp
@@ -19,6 +19,7 @@ CE::MetaField::MetaField(const MetaType& outerType,
 }
 
 CE::MetaField::MetaField(MetaField&&) noexcept = default;
+
 CE::MetaField::~MetaField() = default;
 
 bool CE::MetaField::operator==(const MetaField& other) const

--- a/Source/Meta/MetaFunc.cpp
+++ b/Source/Meta/MetaFunc.cpp
@@ -33,7 +33,7 @@ CE::MetaFunc::MetaFunc(const InvokeT& funcToInvoke,
 }
 
 CE::MetaFunc::MetaFunc(InvokeT&& func, NameOrType&& nameOrOp, std::initializer_list<TypeTraits> paramTypes,
-	std::initializer_list<std::string_view> paramNames, FuncId funcId, UseContructor) :
+	std::initializer_list<std::string_view> paramNames, FuncId funcId, ExplicitlyUseThisConstructor) :
 	mReturn({ *(paramTypes.end() - 1), paramNames.size() > 0 ? *(paramNames.end() - 1) : std::string_view{}}),
 	mParams([&paramNames, &paramTypes]()
 		{
@@ -65,13 +65,13 @@ CE::MetaFunc::MetaFunc(InvokeT&& func, NameOrType&& nameOrOp, std::initializer_l
 
 CE::MetaFunc::MetaFunc(InvokeT&& func, OperatorType op, std::initializer_list<TypeTraits> paramTypes,
 	std::initializer_list<std::string_view> paramNames, FuncId funcId) :
-	MetaFunc(std::move(func), NameOrType{ op }, paramTypes, paramNames, funcId, UseContructor{})
+	MetaFunc(std::move(func), NameOrType{ op }, paramTypes, paramNames, funcId, ExplicitlyUseThisConstructor{})
 {
 }
 
 CE::MetaFunc::MetaFunc(InvokeT&& func, std::string_view name, std::initializer_list<TypeTraits> paramTypes,
 	std::initializer_list<std::string_view> paramNames, FuncId funcId) :
-	MetaFunc(std::move(func), NameOrType{ std::string{ name } }, paramTypes, paramNames, funcId, UseContructor{})
+	MetaFunc(std::move(func), NameOrType{ std::string{ name } }, paramTypes, paramNames, funcId, ExplicitlyUseThisConstructor{})
 {
 }
 

--- a/Source/Meta/MetaType.cpp
+++ b/Source/Meta/MetaType.cpp
@@ -83,6 +83,32 @@ bool CE::MetaType::IsBaseClassOf(const TypeId derivedClassTypeId) const
 	return false;
 }
 
+CE::MetaField& CE::MetaType::AddField(MetaField&& field)
+{
+	ASSERT(&field.GetOuterType() == this);
+
+	MetaField& returnValue = mFields.emplace_back(std::move(field));
+
+#ifdef ASSERTS_ENABLED
+		for (const MetaField& otherField : EachField())
+		{
+			if (&otherField != &field
+				&& otherField.GetName() == field.GetName())
+			{
+				LOG(LogCore, Fatal, "{} has multiple fields with the name {}", mName, field.GetName());
+			}
+		}
+#endif // ASSERTS_ENABLED
+
+	return returnValue;
+}
+
+CE::MetaFunc& CE::MetaType::AddFunc(MetaFunc&& func)
+{
+	const auto nameOrType = func.GetNameOrType();
+	return mFunctions.emplace(std::move(nameOrType), std::move(func))->second;
+}
+
 void CE::MetaType::AddBaseClass(const MetaType& baseClass)
 {
 	mDirectBaseClasses.push_back(baseClass);

--- a/Source/Meta/ReflectedTypes/ENTT/ReflectEntity.cpp
+++ b/Source/Meta/ReflectedTypes/ENTT/ReflectEntity.cpp
@@ -47,20 +47,20 @@ MetaType Reflector<T>::Reflect()
 	type.SetTypeInfo(typeInfo);
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const entt::entity& entity, nullptr_t) { return entity == entt::null; }, OperatorType::equal, MetaFunc::ExplicitParams<const T&, nullptr_t>{}).GetProperties();
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const entt::entity& entity, nullptr_t) { return entity == entt::null; }, OperatorType::equal).GetProperties();
 
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc([](const entt::entity& entity)
 		{
 			return std::to_string(entt::to_integral(entity));
-		}, "ToString", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+		}, "ToString").GetProperties().Add(Props::sIsScriptableTag);
 
 
 	type.AddFunc([](const World& world, const entt::entity& entity)
 		{
 			return world.GetRegistry().Valid(entity);
-		}, "IsAlive", MetaFunc::ExplicitParams<const World&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+		}, "IsAlive").GetProperties().Add(Props::sIsScriptableTag);
 
 
 	type.AddFunc([](World& world, const entt::entity& entity, const ComponentFilter& component)
@@ -72,7 +72,7 @@ MetaType Reflector<T>::Reflect()
 
 			world.GetRegistry().AddComponent(*component.Get(), entity);
 
-		}, "AddComponent", MetaFunc::ExplicitParams<World&, const T&, const ComponentFilter&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "AddComponent").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/GLM/ReflectMat4.cpp
+++ b/Source/Meta/ReflectedTypes/GLM/ReflectMat4.cpp
@@ -18,12 +18,12 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Mat4" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate, MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate).GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign).GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/GLM/ReflectQuat.cpp
+++ b/Source/Meta/ReflectedTypes/GLM/ReflectQuat.cpp
@@ -18,26 +18,26 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Quat" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate, MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](glm::vec3 n) { return glm::quat{ n }; }, "EulerToQuat (Radians)", MetaFunc::ExplicitParams<glm::vec3>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const glm::quat& n) { return glm::eulerAngles(n); }, "QuatToEuler (Radians)", MetaFunc::ExplicitParams<const glm::quat&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](glm::vec3 n) { return glm::quat{ n }; }, "EulerToQuat (Radians)").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const glm::quat& n) { return glm::eulerAngles(n); }, "QuatToEuler (Radians)").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc([](const glm::quat& n)
 	{
 			return Math::QuatToDirectionXZ(n);
-	}, "QuatToXZDirection (vec2)", MetaFunc::ExplicitParams<const glm::quat&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	}, "QuatToXZDirection (vec2)").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc([](const glm::quat& n)
 		{
 			return Math::QuatToDirection(n);
-		}, "QuatToDirection (vec3)", MetaFunc::ExplicitParams<const glm::quat&>{}).GetProperties().Add(Props::sIsScriptableTag);
+		}, "QuatToDirection (vec3)").GetProperties().Add(Props::sIsScriptableTag);
 		type.AddFunc([](glm::vec2 n)
 			{
 				return Math::Direction2DToXZQuatOrientation(n);
-			}, "Direction2DToXZQuatOrientation", MetaFunc::ExplicitParams<glm::vec2>{}).GetProperties().Add(Props::sIsScriptableTag);
+			}, "Direction2DToXZQuatOrientation").GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign).GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/GLM/ReflectVec2.cpp
+++ b/Source/Meta/ReflectedTypes/GLM/ReflectVec2.cpp
@@ -18,13 +18,13 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Vec2" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::plus<T>(), OperatorType::add, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::minus<T>(), OperatorType::subtract, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::divides<T>(), OperatorType::divides, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate, MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::plus<T>(), OperatorType::add).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::minus<T>(), OperatorType::subtract).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::divides<T>(), OperatorType::divides).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate).GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&)>(&max), "Max").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&)>(&min), "Min").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&, const T&)>(&glm::clamp), "Clamp", "Value", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
@@ -34,7 +34,7 @@ MetaType Reflector<T>::Reflect()
 	type.AddFunc([](const T a, const T b) -> float
 		{
 			return cross(glm::vec3(a.x, 0.f, a.y), glm::vec3(b.x, 0.f, b.y)).y;
-		}, "2DCross", MetaFunc::ExplicitParams<const T, const T>{}, "DirectionA", "DirectionB").GetProperties().Add(Props::sIsScriptableTag);
+		}, "2DCross", "DirectionA", "DirectionB").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&)>(&normalize), "Normalize").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&)>(&radians), "ToRadians", "Degrees", "Radians").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&)>(&degrees), "ToDegrees", "Radians", "Degrees").GetProperties().Add(Props::sIsScriptableTag);
@@ -42,21 +42,21 @@ MetaType Reflector<T>::Reflect()
 	type.AddFunc(static_cast<float(*)(const T&, const T&)>(&distance2), "Distance2", "LocationA", "LocationB").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<float(*)(const T&)>(&length), "Length").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<float(*)(const T&)>(&length2), "Length2").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const float& x, const float& y) { return T{ x, y }; }, "MakeVec2", MetaFunc::ExplicitParams<const float&, const float&>{}, "X", "Y").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& v, const float& s) { return v * s; }, "Scale", MetaFunc::ExplicitParams<const T&, const float&>{}, "Vector", "Scalar", "Product").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const float& x, const float& y) { return T{ x, y }; }, "MakeVec2", "X", "Y").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& v, const float& s) { return v * s; }, "Scale", "Vector", "Scalar", "Product").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const float&, const float&)>(&Math::ClampLength), "ClampLength").GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign).GetProperties().Add(Props::sIsScriptableTag);
 
 	type.AddFunc([](const T n) -> std::string
 	{
 			return "X: " + std::to_string(n.x) + "; Y: " + std::to_string(n.y);
-	}, "ToString", MetaFunc::ExplicitParams<const T>{}).GetProperties().Add(Props::sIsScriptableTag);
+	}, "ToString").GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/GLM/ReflectVec3.cpp
+++ b/Source/Meta/ReflectedTypes/GLM/ReflectVec3.cpp
@@ -19,13 +19,13 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Vec3" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::plus<T>(), OperatorType::add, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::minus<T>(), OperatorType::subtract, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::divides<T>(), OperatorType::divides, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate, MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::plus<T>(), OperatorType::add).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::minus<T>(), OperatorType::subtract).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::divides<T>(), OperatorType::divides).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate).GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&)>(&max), "Max").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&)>(&min), "Min").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&, const T&)>(&glm::clamp), "Clamp", "Value", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
@@ -41,24 +41,24 @@ MetaType Reflector<T>::Reflect()
 	type.AddFunc(static_cast<float(*)(const T&, const T&)>(&distance2), "Distance2", "LocationA", "LocationB").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<float(*)(const T&)>(&length), "Length").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<float(*)(const T&)>(&length2), "Length2").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const float& x, const float& y, const float& z) { return T{ x, y, z }; }, "MakeVec3", MetaFunc::ExplicitParams<const float&, const float&, const float&>{}, "X", "Y", "Z").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& v, const float& s) { return v * s; }, "Scale", MetaFunc::ExplicitParams<const T&, const float&>{}, "Vector", "Scalar", "Product").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const float& x, const float& y, const float& z) { return T{ x, y, z }; }, "MakeVec3", "X", "Y", "Z").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& v, const float& s) { return v * s; }, "Scale", "Vector", "Scalar", "Product").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const float&, const float&)>(&Math::ClampLength), "ClampLength").GetProperties().Add(Props::sIsScriptableTag);
 
 
 	
 
-	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign).GetProperties().Add(Props::sIsScriptableTag);
 
 	type.AddFunc([](const T n) -> std::string
 		{
 			return "X: " + std::to_string(n.x) + "; Y: " + std::to_string(n.y) + "; Z: " + std::to_string(n.z);
-		}, "ToString", MetaFunc::ExplicitParams<const T>{}).GetProperties().Add(Props::sIsScriptableTag);
+		}, "ToString").GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/GLM/ReflectVec4.cpp
+++ b/Source/Meta/ReflectedTypes/GLM/ReflectVec4.cpp
@@ -19,13 +19,13 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Vec4" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::plus<T>(), OperatorType::add, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::minus<T>(), OperatorType::subtract, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::divides<T>(), OperatorType::divides, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate, MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::plus<T>(), OperatorType::add).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::minus<T>(), OperatorType::subtract).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::divides<T>(), OperatorType::divides).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate).GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&)>(&max), "Max").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&)>(&min), "Min").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const T&, const T&)>(&glm::clamp), "Clamp", "Value", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
@@ -41,21 +41,21 @@ MetaType Reflector<T>::Reflect()
 	type.AddFunc(static_cast<float(*)(const T&, const T&)>(&distance2), "Distance2", "LocationA", "LocationB").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<float(*)(const T&)>(&length), "Length").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<float(*)(const T&)>(&length2), "Length2").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const float& x, const float& y, const float& z, const float& w) { return T{ x, y, z, w }; }, "MakeVec4", MetaFunc::ExplicitParams<const float&, const float&, const float&, const float&>{}, "X", "Y", "Z", "W").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& v, const float& s) { return v * s; }, "Scale", MetaFunc::ExplicitParams<const T&, const float&>{}, "Vector", "Scalar", "Product").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const float& x, const float& y, const float& z, const float& w) { return T{ x, y, z, w }; }, "MakeVec4", "X", "Y", "Z", "W").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& v, const float& s) { return v * s; }, "Scale", "Vector", "Scalar", "Product").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(const T&, const float&, const float&)>(&Math::ClampLength), "ClampLength").GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign).GetProperties().Add(Props::sIsScriptableTag);
 
 	type.AddFunc([](const T n) -> std::string
 		{
 			return "X: " + std::to_string(n.x) + "; Y: " + std::to_string(n.y) + "; Z: " + std::to_string(n.z) + "; W: " + std::to_string(n.w);
-		}, "ToString", MetaFunc::ExplicitParams<const T>{}).GetProperties().Add(Props::sIsScriptableTag);
+		}, "ToString").GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/PrimitiveTypes/ReflectBool.cpp
+++ b/Source/Meta/ReflectedTypes/PrimitiveTypes/ReflectBool.cpp
@@ -6,7 +6,6 @@
 #include "Meta/MetaProps.h"
 #include "Utilities/Reflect/ReflectFieldType.h"
 #include "Meta/ReflectedTypes/STD/ReflectVector.h"
-#include "Meta/ReflectedTypes/STD/ReflectVector.h"
 
 using namespace CE;
 using T = bool;
@@ -17,15 +16,15 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Bool" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& b) -> std::string { return b ? "true" : "false"; }, "ToString", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<int32>(f); }, "ToInt32", MetaFunc::ExplicitParams <const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<uint32>(f); }, "ToUInt32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<float32>(f); }, "ToFloat32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::logical_and<T>(), OperatorType::logical_and, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::logical_or<T>(), OperatorType::logical_or, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::logical_not<T>(), OperatorType::negate, MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& b) -> std::string { return b ? "true" : "false"; }, "ToString").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<int32>(f); }, "ToInt32").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<uint32>(f); }, "ToUInt32").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<float32>(f); }, "ToFloat32").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::logical_and<T>(), OperatorType::logical_and).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::logical_or<T>(), OperatorType::logical_or).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::logical_not<T>(), OperatorType::negate).GetProperties().Add(Props::sIsScriptableTag);
 	ReflectFieldType<T>(type);
 
 	return type;

--- a/Source/Meta/ReflectedTypes/PrimitiveTypes/ReflectFloat32.cpp
+++ b/Source/Meta/ReflectedTypes/PrimitiveTypes/ReflectFloat32.cpp
@@ -17,24 +17,24 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Float" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::plus<T>(), OperatorType::add, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::minus<T>(), OperatorType::subtract, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::divides<T>(), OperatorType::divides, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::plus<T>(), OperatorType::add).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::minus<T>(), OperatorType::subtract).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::divides<T>(), OperatorType::divides).GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(&fmodf, OperatorType::modulus).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::greater<T>(), OperatorType::greater, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::less<T>(), OperatorType::less, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::greater_equal<T>(), OperatorType::greater_equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::less_equal<T>(), OperatorType::less_equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate, MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::greater<T>(), OperatorType::greater).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::less<T>(), OperatorType::less).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::greater_equal<T>(), OperatorType::greater_equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::less_equal<T>(), OperatorType::less_equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate).GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T, T)>(&glm::max), "Max").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T, T)>(&glm::min), "Min").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T, T, T)>(&glm::clamp), "Clamp", "Value", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<std::string(*)(T)>(&std::to_string), "ToString").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<int32>(f); }, "ToInt32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<uint32>(f); }, "ToUInt32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<int32>(f); }, "ToInt32").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<uint32>(f); }, "ToUInt32").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T)>(&glm::radians), "ToRadians", "Degrees", "Radians").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T)>(&glm::degrees), "ToDegrees", "Radians", "Degrees").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(&sinf, "Sin").GetProperties().Add(Props::sIsScriptableTag);
@@ -49,13 +49,13 @@ MetaType Reflector<T>::Reflect()
 	type.AddFunc(&CE::Math::lerpInv<T>, "LerpInv", "Min", "Max", "Value", "T").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(&CE::Math::lerp<T>, "Lerp", "Min", "Max", "T", "Value").GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n = fmodf(n, l); return n; }, OperatorType::modulus_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n = fmodf(n, l); return n; }, OperatorType::modulus_assign).GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/PrimitiveTypes/ReflectInt32.cpp
+++ b/Source/Meta/ReflectedTypes/PrimitiveTypes/ReflectInt32.cpp
@@ -17,32 +17,32 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Int" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::plus<T>(), OperatorType::add, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::minus<T>(), OperatorType::subtract, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::divides<T>(), OperatorType::divides, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::modulus<T>(), OperatorType::modulus, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::greater<T>(), OperatorType::greater, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::less<T>(), OperatorType::less, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::greater_equal<T>(), OperatorType::greater_equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::less_equal<T>(), OperatorType::less_equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate, MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::plus<T>(), OperatorType::add).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::minus<T>(), OperatorType::subtract).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::divides<T>(), OperatorType::divides).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::modulus<T>(), OperatorType::modulus).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::greater<T>(), OperatorType::greater).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::less<T>(), OperatorType::less).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::greater_equal<T>(), OperatorType::greater_equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::less_equal<T>(), OperatorType::less_equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& n) { return -n; }, OperatorType::negate).GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T, T)>(&glm::max), "Max").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T, T)>(&glm::min), "Min").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T, T, T)>(&glm::clamp), "Clamp", "Value", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<std::string(*)(T)>(&std::to_string), "ToString").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<uint32>(f); }, "ToUInt32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<float32>(f); }, "ToFloat32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<uint32>(f); }, "ToUInt32").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<float32>(f); }, "ToFloat32").GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n %= l; return n; }, OperatorType::modulus_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n %= l; return n; }, OperatorType::modulus_assign).GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/PrimitiveTypes/ReflectUint32.cpp
+++ b/Source/Meta/ReflectedTypes/PrimitiveTypes/ReflectUint32.cpp
@@ -16,30 +16,30 @@ MetaType Reflector<T>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "Uint" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::plus<T>(), OperatorType::add, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::minus<T>(), OperatorType::subtract, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::divides<T>(), OperatorType::divides, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::modulus<T>(), OperatorType::modulus, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::greater<T>(), OperatorType::greater, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::less<T>(), OperatorType::less, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::greater_equal<T>(), OperatorType::greater_equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::less_equal<T>(), OperatorType::less_equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::plus<T>(), OperatorType::add).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::minus<T>(), OperatorType::subtract).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::multiplies<T>(), OperatorType::multiplies).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::divides<T>(), OperatorType::divides).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::modulus<T>(), OperatorType::modulus).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::greater<T>(), OperatorType::greater).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::less<T>(), OperatorType::less).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::greater_equal<T>(), OperatorType::greater_equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::less_equal<T>(), OperatorType::less_equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T, T)>(&glm::max), "Max").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<T(*)(T, T)>(&glm::min), "Min").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(static_cast<std::string(*)(T)>(&std::to_string), "ToString").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<int32>(f); }, "ToInt32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](const T& f) { return static_cast<float32>(f); }, "ToFloat32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<int32>(f); }, "ToInt32").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](const T& f) { return static_cast<float32>(f); }, "ToFloat32").GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement, MetaFunc::ExplicitParams<T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](T& n, const T& l) -> T& { n %= l; return n; }, OperatorType::modulus_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { ++n; return n; }, OperatorType::increment).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n) -> T& { --n; return n; }, OperatorType::decrement).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n -= l; return n; }, OperatorType::subtract_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n *= l; return n; }, OperatorType::multiplies_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n /= l; return n; }, OperatorType::divides_assign).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](T& n, const T& l) -> T& { n %= l; return n; }, OperatorType::modulus_assign).GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Meta/ReflectedTypes/STD/ReflectString.cpp
+++ b/Source/Meta/ReflectedTypes/STD/ReflectString.cpp
@@ -18,20 +18,20 @@ MetaType Reflector<T>::Reflect()
 	MetaType typestring{ MetaType::T<T>{}, "String" };
 
 	typestring.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	typestring.AddFunc(std::plus<T>(), OperatorType::add, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign, MetaFunc::ExplicitParams<T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc(std::greater<T>(), OperatorType::greater, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc(std::less<T>(), OperatorType::less, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc(std::less<T>(), OperatorType::less, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc(std::less_equal<T>(), OperatorType::less_equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc([](const T& str) { return std::stoi(str); }, "ToInt32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc([](const T& str) { return static_cast<uint32>(std::stoul(str)); }, "ToUInt32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	typestring.AddFunc([](const T& str) { return std::stof(str); }, "ToFloat32", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc(std::plus<T>(), OperatorType::add).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc([](T& n, const T& l) -> T& { n += l; return n; }, OperatorType::add_assign).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc(std::greater<T>(), OperatorType::greater).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc(std::less<T>(), OperatorType::less).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc(std::less<T>(), OperatorType::less).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc(std::less_equal<T>(), OperatorType::less_equal).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc([](const T& str) { return std::stoi(str); }, "ToInt32").GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc([](const T& str) { return static_cast<uint32>(std::stoul(str)); }, "ToUInt32").GetProperties().Add(Props::sIsScriptableTag);
+	typestring.AddFunc([](const T& str) { return std::stof(str); }, "ToFloat32").GetProperties().Add(Props::sIsScriptableTag);
 	typestring.AddFunc([]([[maybe_unused]] const T& str) {
 		LOG(LogScripting, Message, "{}", str);
-		}, "Print", MetaFunc::ExplicitParams<const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+		}, "Print").GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(typestring);
 	return typestring;

--- a/Source/Systems/PhysicsSystem.cpp
+++ b/Source/Systems/PhysicsSystem.cpp
@@ -111,7 +111,7 @@ namespace CE::Internal
 		}
 
 		template<>
-		STATIC_SPECIALIZATION bool Callback<TransformedDiskColliderComponent>(entt::entity entity2, entt::entity entity1, const PhysicsBody2DComponent& body1, const Registry& reg)
+		bool Callback<TransformedDiskColliderComponent>(entt::entity entity2, entt::entity entity1, const PhysicsBody2DComponent& body1, const Registry& reg)
 		{
 			if (entity1 >= entity2)
 			{

--- a/Source/Systems/PhysicsSystem.cpp
+++ b/Source/Systems/PhysicsSystem.cpp
@@ -504,7 +504,7 @@ CE::MetaType CE::PhysicsSystem::Reflect()
 		{
 			return ResolveDiskCollision({ entity1 , entity2, depth, normalFor1, contactPoint }, bodyToMove, otherBody, bodyPosition).mResolvedPosition;
 		},
-		"ResolveCollision", MetaFunc::ExplicitParams<entt::entity , entt::entity , float, glm::vec2, glm::vec2, const PhysicsBody2DComponent&, const PhysicsBody2DComponent&, glm::vec2>{}, 
+		"ResolveCollision", 
 		"Entity1", "Entity2", "Depth", "NormalFor1", "ContactPoint", "PhysicsBodyToMove", "OtherPhysicsBody", "BodyPosition").GetProperties().Add(Props::sIsScriptableTag);
 
 	return metaType;

--- a/Source/UnitTests/AssetManagerUnitTests.cpp
+++ b/Source/UnitTests/AssetManagerUnitTests.cpp
@@ -36,7 +36,7 @@ UNIT_TEST(AssetManagerUnitTests, MultiThreadedAssetLoadingUnloading)
 	std::vector<std::future<UnitTest::Result>> loadResults{};
 	std::vector<std::future<void>> unloadResults{};
 
-	for (int i = 0; i < ThreadPool::Get().NumberOfThreads(); i += 2)
+	for (size_t i = 0; i < ThreadPool::Get().NumberOfThreads(); i += 2)
 	{
 		loadResults.emplace_back(ThreadPool::Get().Enqueue(loadAssets));
 		unloadResults.emplace_back(ThreadPool::Get().Enqueue(unloadAssets));

--- a/Source/UnitTests/MetaUnitTests.cpp
+++ b/Source/UnitTests/MetaUnitTests.cpp
@@ -47,7 +47,7 @@ UNIT_TEST(Meta, FunctionHash)
 		return UnitTest::Failure;
 	}
 
-	const MetaFunc func1{ [](int32, float32) -> glm::mat4 { return {}; }, "func1",  MetaFunc::ExplicitParams<int32, float32>{} };
+	const MetaFunc func1{ [](int32, float32) -> glm::mat4 { return {}; }, "func1" };
 
 	if (func1.GetFuncId() != CE::MakeFuncId<glm::mat4(int32, float32)>())
 	{

--- a/Source/Utilities/ComponentFilter.cpp
+++ b/Source/Utilities/ComponentFilter.cpp
@@ -21,8 +21,8 @@ CE::MetaType Reflector<CE::ComponentFilter>::Reflect()
 	MetaType type{ MetaType::T<T>{}, "ComponentType" };
 
 	type.GetProperties().Add(Props::sIsScriptableTag).Add(Props::sIsScriptOwnableTag);
-	type.AddFunc(std::equal_to<T>(), OperatorType::equal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal, MetaFunc::ExplicitParams<const T&, const T&>{}).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::equal_to<T>(), OperatorType::equal).GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc(std::not_equal_to<T>(), OperatorType::inequal).GetProperties().Add(Props::sIsScriptableTag);
 
 	ReflectFieldType<T>(type);
 

--- a/Source/Utilities/Random.cpp
+++ b/Source/Utilities/Random.cpp
@@ -54,9 +54,9 @@ CE::MetaType CE::Random::Reflect()
 	type.AddFunc(&Random::Range<uint32>, "Uint Range", "Min (Inclusive)", "Max (Exclusive)").GetProperties().Add(Props::sIsScriptableTag);
 	type.AddFunc(&Random::Range<float>, "Float Range", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
 
-	type.AddFunc([](glm::vec2 min, glm::vec2 max) { return Range(min, max);  }, "Vec2 Range", MetaFunc::ExplicitParams<glm::vec2, glm::vec2>{}, "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](glm::vec3 min, glm::vec3 max) { return Range(min, max);  }, "Vec3 Range", MetaFunc::ExplicitParams<glm::vec3, glm::vec3>{}, "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
-	type.AddFunc([](glm::vec4 min, glm::vec4 max) { return Range(min, max);  }, "Vec4 Range", MetaFunc::ExplicitParams<glm::vec4, glm::vec4>{}, "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](glm::vec2 min, glm::vec2 max) { return Range(min, max);  }, "Vec2 Range", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](glm::vec3 min, glm::vec3 max) { return Range(min, max);  }, "Vec3 Range", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
+	type.AddFunc([](glm::vec4 min, glm::vec4 max) { return Range(min, max);  }, "Vec4 Range", "Min", "Max").GetProperties().Add(Props::sIsScriptableTag);
 
     return type;
 }

--- a/Source/World/Physics.cpp
+++ b/Source/World/Physics.cpp
@@ -153,12 +153,12 @@ CE::MetaType CE::Physics::Reflect()
 	type.AddFunc([](const World& world, glm::vec2 centre, float radius, const CollisionRules& filter)
 		{
 			return world.GetPhysics().FindAllWithinShape(TransformedDisk{ centre, radius }, filter);
-		}, "Find all bodies in radius", MetaFunc::ExplicitParams<const World&, glm::vec2, float, const CollisionRules&>{}, "Centre", "Radius", "Filter").GetProperties().Add(Props::sIsScriptableTag);
+		}, "Find all bodies in radius", "Centre", "Radius", "Filter").GetProperties().Add(Props::sIsScriptableTag);
 
 	type.AddFunc([](const World& world, glm::vec2 min, glm::vec2 max, const CollisionRules& filter)
 		{
 			return world.GetPhysics().FindAllWithinShape(TransformedAABB{ min, max }, filter);
-		}, "Find all bodies in box", MetaFunc::ExplicitParams<const World&, glm::vec2, glm::vec2, const CollisionRules&>{}, "Min", "Max", "Filter").GetProperties().Add(Props::sIsScriptableTag);
+		}, "Find all bodies in box", "Min", "Max", "Filter").GetProperties().Add(Props::sIsScriptableTag);
 
 	return type;
 }

--- a/Source/World/World.cpp
+++ b/Source/World/World.cpp
@@ -273,64 +273,63 @@ CE::MetaType CE::World::Reflect()
 	type.AddFunc([](const World& world)
 		{
 			return world.HasBegunPlay();
-		}, "HasBegunPlay", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "HasBegunPlay").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](const World& world)
 		{
 			return world.GetCurrentTimeScaled();
-		}, "GetCurrentTimeScaled", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "GetCurrentTimeScaled").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](const World& world)
 		{
 			return world.GetCurrentTimeReal();
-		}, "GetCurrentTimeReal", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "GetCurrentTimeReal").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](const World& world)
 		{
 			return world.GetTimeScale();
-		}, "GetTimeScale", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "GetTimeScale").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](World& world, float timescale)
 		{
 			world.SetTimeScale(timescale);
-		}, "SetTimeScale", MetaFunc::ExplicitParams<World&, float>{}, "TimeScale").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "SetTimeScale", "TimeScale").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world)
 		{
 			return world.IsPaused();
-		}, "IsPaused", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "IsPaused").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](World& world)
 		{
 			world.Pause();
-		}, "Pause", MetaFunc::ExplicitParams<World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Pause").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](World& world)
 		{
 			world.Unpause();
-		}, "Unpause", MetaFunc::ExplicitParams<World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Unpause").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](World& world, bool isPaused)
 		{
 			world.SetIsPaused(isPaused);
-		}, "SetIsPaused", MetaFunc::ExplicitParams<World&, bool>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "SetIsPaused").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world)
 		{
 			return world.HasBegunPlay();
-		}, "HasBegunPlay", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "HasBegunPlay").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](World& world)
 		{
 			world.RequestEndplay();
-		}, "RequestEndPlay", MetaFunc::ExplicitParams<World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "RequestEndPlay").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](World& world, const AssetHandle<Level>& level)
 		{
 			world.TransitionToLevel(level);
 		},
-		"TransitionToLevel", 
-		MetaFunc::ExplicitParams<World&, const AssetHandle<Level>&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		"TransitionToLevel").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world)
 		{
@@ -351,17 +350,17 @@ CE::MetaType CE::World::Reflect()
 			}
 
 			return returnValue;
-		}, "Get all entities", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "Get all entities").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](World& world)
 		{
 			world.GetRegistry().Clear();
-		}, "Clear", MetaFunc::ExplicitParams<World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Clear").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](World& world)
 		{
 			return world.GetRegistry().Create();
-		}, "Spawn entity", MetaFunc::ExplicitParams<World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Spawn entity").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](World& world, const AssetHandle<Prefab>& prefab)
 		{
@@ -371,7 +370,7 @@ CE::MetaType CE::World::Reflect()
 			}
 
 			return world.GetRegistry().CreateFromPrefab(*prefab);
-		}, "Spawn prefab", MetaFunc::ExplicitParams<World&, const AssetHandle<Prefab>&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Spawn prefab").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](World& world, const AssetHandle<Prefab>& prefab, const glm::vec3 position, const glm::quat orientation, const glm::vec3 scale, TransformComponent* parent) -> entt::entity
 		{
@@ -387,13 +386,13 @@ CE::MetaType CE::World::Reflect()
 			}
 
 			return world.GetRegistry().CreateFromPrefab(*prefab, entt::null, &position, &orientation, &scale, parent);
-		}, "Spawn prefab at", MetaFunc::ExplicitParams<World&, const AssetHandle<Prefab>&, glm::vec3, glm::quat, glm::vec3, TransformComponent*>{},
+		}, "Spawn prefab at",
 			"Prefab", "LocalPosition", "LocalOrientation", "LocalScale", "Parent").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](World& world, const entt::entity& entity, bool destroyChildren)
 		{
 			world.GetRegistry().Destroy(entity, destroyChildren);
-		}, "Destroy entity", MetaFunc::ExplicitParams<World&, const entt::entity&, bool>{}, "Entity", "DestroyChildren").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Destroy entity", "Entity", "DestroyChildren").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world, const std::string& name) -> entt::entity
 		{
@@ -408,7 +407,7 @@ CE::MetaType CE::World::Reflect()
 			}
 
 			return entt::null;
-		}, "Find entity with name", MetaFunc::ExplicitParams<const World&, const std::string&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Find entity with name").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world, const std::string& name)
 		{
@@ -424,7 +423,7 @@ CE::MetaType CE::World::Reflect()
 			}
 
 			return returnValue;
-		}, "Find all entities with name", MetaFunc::ExplicitParams<const World&, const std::string&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Find all entities with name").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world, const ComponentFilter& component) -> entt::entity
 		{
@@ -435,7 +434,7 @@ CE::MetaType CE::World::Reflect()
 				return entt::null;
 			}
 			return *view.begin();
-		}, "Find entity with component", MetaFunc::ExplicitParams<const World&, const ComponentFilter&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Find entity with component").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world, const ComponentFilter& component)
 		{
@@ -446,7 +445,7 @@ CE::MetaType CE::World::Reflect()
 			returnValue.insert(returnValue.end(), view.begin(), view.end());
 
 			return returnValue;
-		}, "Find all entities with component", MetaFunc::ExplicitParams<const World&, const ComponentFilter&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Find all entities with component").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world, const std::vector<ComponentFilter>& components) -> entt::entity
 		{
@@ -457,7 +456,7 @@ CE::MetaType CE::World::Reflect()
 				return entt::null;
 			}
 			return *view.begin();
-		}, "Find entity with components", MetaFunc::ExplicitParams<const World&, const std::vector<ComponentFilter>&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Find entity with components").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world, const std::vector<ComponentFilter>& components)
 		{
@@ -468,27 +467,27 @@ CE::MetaType CE::World::Reflect()
 			returnValue.insert(returnValue.end(), view.begin(), view.end());
 
 			return returnValue;
-		}, "Find all entities with components", MetaFunc::ExplicitParams<const World&, const std::vector<ComponentFilter>&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
+		}, "Find all entities with components").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, false);
 
 	type.AddFunc([](const World& world, glm::vec2 screenPosition, float distanceFromCamera)
 		{
 			return world.GetViewport().ScreenToWorld(screenPosition, distanceFromCamera);
-		}, "ScreenToWorld", MetaFunc::ExplicitParams<const World&, glm::vec2, float>{}, "Screen position", "Distance from camera").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "ScreenToWorld", "Screen position", "Distance from camera").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](const World& world, glm::vec2 screenPosition, float planeHeight)
 		{
 			return world.GetViewport().ScreenToWorldPlane(screenPosition, planeHeight);
-		}, "ScreenToWorldPlane", MetaFunc::ExplicitParams<const World&, glm::vec2, float>{}, "Screen position", "Plane height").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "ScreenToWorldPlane", "Screen position", "Plane height").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](const World& world)
 		{
 			return world.GetScaledDeltaTime();
-		}, "GetScaledDeltaTime", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
+		}, "GetScaledDeltaTime").GetProperties().Add(Props::sIsScriptableTag).Set(Props::sIsScriptPure, true);
 
 	type.AddFunc([](const World& world)
 		{
 			return world.GetRealDeltaTime();
-		}, "GetRealDeltaTime", MetaFunc::ExplicitParams<const World&>{}).GetProperties().Add(Props::sIsScriptableTag);
+		}, "GetRealDeltaTime").GetProperties().Add(Props::sIsScriptableTag);
 
 	return type;
 }


### PR DESCRIPTION
Improved syntax for reflecting functions, MetaFunc::ExplicitParams is no longer needed

Also reduced size of executable by 50mb by moving more code to the template agnostic sections